### PR TITLE
Fix/languagedropdown display bug

### DIFF
--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -43,6 +43,8 @@ const ConfigDefaults = {
 
 ## Use in React Hooks
 
+Default key separator is set to `|`.
+
 ```
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -59,7 +59,7 @@ export function Header(props) {
 			:
 				<Nav className="ml-auto" navbar>
 					{HeaderService.Items.map((item, idx) => (
-						window.innerWidth < 1024 && item.component.name !== undefined && item.component.name === "LanguageDropdown" ?
+						window.innerWidth < 1024 && item.componentProps.children !== undefined && item.componentProps.children === "LanguageDropdown" ?
 							<NavItem key={idx}>
 								<item.component key={item} {...item.componentProps} app={props.app}/>
 							</NavItem>

--- a/src/modules/i18n/index.js
+++ b/src/modules/i18n/index.js
@@ -13,7 +13,7 @@ export default class I18nModule extends Module {
 
 	initialize() {
 		const headerService = this.App.locateService("HeaderService");
-		headerService.addComponent(LanguageDropdown);
+		headerService.addComponent(LanguageDropdown, {children: "LanguageDropdown"});
 	}
 
 }


### PR DESCRIPTION
This PR fix language dropdown bug, when the project was build with `yarn build` command. Previously, the dropdown was not available on small screens (cellphones). The reason was, that when build by `yarn build` command, the name of the dropdown has been changed from `LanguageDropdown` to `jo` and thus has not been catched by the condition. The solution was just to add the name to the component props of the dropdown. Also default i18n keySeparator of the project has been mentioned in the documentation.