### PR TITLE
advmode: Add second shortcut for enabling/disabling advmode on Windows

### DIFF
--- a/doc/advmode.md
+++ b/doc/advmode.md
@@ -1,6 +1,6 @@
 # ASAB WebUI Advanced mode
 
-The advanced mode can be activated by pressing `CTRL 1` - and disabled by pressing `CTRL 1` again.
+The advanced mode can be activated by pressing `CTRL 1` for Linux and `CTRL Q` for Windows - and disabled by pressing `CTRL 1` or `CTRL Q` again.
 
 This mode can be used to display technical infromations such as JSONs on the WebUI.
 The advanced mode is `off` by default.

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -217,8 +217,8 @@ it is accessible by the sidebar toggler button.
 
 	_handleKeyUp(event) {
 
-		// CTRL-A enables the advanced mode
-		if (event.key == '1' && event.ctrlKey) {
+		// CTRL+Q (Windows) or CTRL+1 (Linux) enables the advanced mode
+		if ((event.ctrlKey && event.code === 'KeyQ') || (event.code === 'Digit1' && event.ctrlKey)) {
 			this.setAdvancedMode(0);
 		}
 


### PR DESCRIPTION
Issue: Shortcut Ctrl+1 is reserved by Windows OS (switching between tabs, works for all browsers)

Changes:
- Added second shortcut for Windows (Ctrl+Q)
- Changed event.key to event.code
- Edit documentation 