### PR TITLE
Ensure disabled button on undefined resources in userinfo or on empty userinfo

### DIFF
--- a/src/modules/auth/ButtonWithAuthz.js
+++ b/src/modules/auth/ButtonWithAuthz.js
@@ -52,7 +52,7 @@ import { useTranslation } from 'react-i18next';
 
 export function ButtonWithAuthz(props) {
 	const { t, i18n } = useTranslation();
-	let disabled = props.resources.indexOf(props.resource) == -1;
+	let disabled = props.resources ? props.resources.indexOf(props.resource) == -1 : true;
 
 	// Check on title eventually passed in the props
 	if (disabled) {


### PR DESCRIPTION
This PR implement forgotten condition on `disabled` of `ButtonWithAuthz` component, where missing userinfo will be evaluated as "no permissions" and it will not cause the crash of the application. This should ensure situation, when userinfo is an empty object `{}` or the `resources` are undefined.