### PR TITLE
Move ASAB-config module navigation under the Maintenance tab of the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@
 ### Refactoring
 
 - Renaming configuration option FAKE_USERINFO to MOCK_USERINFO and refactoring code accordingly (INDIGO Sprint 210406, [!91](https://github.com/TeskaLabs/asab-webui/pull/91))
+
+- Moving ASAB-Config module navigation under the `Maintenance` tab in the sidebar (INDIGO Sprint 210406, [!92](https://github.com/TeskaLabs/asab-webui/pull/92))

--- a/src/modules/asab-config/index.js
+++ b/src/modules/asab-config/index.js
@@ -19,12 +19,6 @@ export default class ConfigModule extends Module {
 			component: ConfigContainer,
 		});
 
-		this.Navigation.addItem({
-			name: "Configuration",
-			url: "/config/$/$",
-			icon: 'cil-settings',
-		});
-
 		this.Router.addRoute({
 			path: "/config/microservices",
 			exact: true,
@@ -33,9 +27,20 @@ export default class ConfigModule extends Module {
 		});
 
 		this.Navigation.addItem({
-			name: "Microservices",
-			url: "/config/microservices",
-			icon: 'cil-list',
+			name: 'Maintenance',
+			icon: 'cil-apps-settings',
+			children: [
+				{
+					name: "Configuration",
+					url: "/config/$/$",
+					icon: 'cil-settings',
+				},
+				{
+					name: "Microservices",
+					url: "/config/microservices",
+					icon: 'cil-list',
+				}
+			]
 		});
 
 	}


### PR DESCRIPTION
This PR moves the navigation of ASAB config under the `Maintenance` tab as it was discussed on review. It should improve the orientation of the user in application sidebar.