### PR TITLE
Remove moment/locales (except czech and english)

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -30,6 +30,7 @@
 	"style-loader": "^1.1.3",
 	"uglifyjs-webpack-plugin": "^2.0.1",
 	"webpack": "^4.42.0",
+	"webpack-bundle-analyzer": "^4.4.1",
 	"webpack-cli": "^3.3.11",
 	"webpack-dev-server": "^3.10.3",
 	"webpack-node-externals": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"style-loader": "^1.1.3",
 		"uglifyjs-webpack-plugin": "^2.0.1",
 		"webpack": "^4.42.0",
+		"webpack-bundle-analyzer": "^4.4.1",
 		"webpack-cli": "^3.3.11",
 		"webpack-dev-server": "^3.10.3",
 		"webpack-node-externals": "^1.7.2",

--- a/webpack/webpack.build.js
+++ b/webpack/webpack.build.js
@@ -7,6 +7,7 @@ const InterpolateHtmlPlugin = require('interpolate-html-plugin');
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const common = require("./common");
 
 
@@ -70,6 +71,11 @@ module.exports = {
 					}
 				}),
 				new OptimizeCssAssetsPlugin(),
+				// Remove moment locales from bundle except those which are defined as second parameter
+				new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /en-gb|cs/),
+				// Uncomment BundleAnalyzerPlugin in case you want to analyze bundle size (also uncomment import of this plugin above)
+				// And comment it before making Pull Request/ Merge Request
+				// new BundleAnalyzerPlugin()
 			],
 			optimization: {
 				minimize: true,

--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -4,6 +4,7 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const InterpolateHtmlPlugin = require('interpolate-html-plugin');
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
+// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const common = require("./common");
 // const OptimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 
@@ -52,6 +53,11 @@ module.exports = {
 				new ExtractTextPlugin('assets/css/styles.css'),
 				// Minimizes styles.css
 				// new OptimizeCssAssetsPlugin()
+				// Remove moment locales from bundle except those which are defined as second parameter
+				new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /en-gb|cs/),
+				// Uncomment BundleAnalyzerPlugin in case you want to analyze bundle size (also uncomment import of this plugin above)
+				// And comment it before making Pull Request/ Merge Request
+				// new BundleAnalyzerPlugin()
 			]
 		};
 	}


### PR DESCRIPTION
Moment.js package includes locales for itself. By removing most of it (I kept only czech and english) we can reduce size of bundle by 354KB (1020KB -> 666KB). Also I attach pictures of webpack-analyzer-plugin to show how big was those locales in compare with other packages
<img width="1440" alt="asab-webui-without-locales" src="https://user-images.githubusercontent.com/37152497/116108730-7740ed80-a6b4-11eb-8a1e-53a639a38a13.png">
<img width="1440" alt="asab-webui-with-locales" src="https://user-images.githubusercontent.com/37152497/116108697-70b27600-a6b4-11eb-8c97-fed83bfd28df.png">

