### PR TITLE
Return DateTime multiplier for timestamp in seconds (by 1000) and add support of timestamp in milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 - Delete multiplier in DateTime component in order to use proper timestamp (milliseconds) (INDIGO Sprint 210430, [a0c35f5](https://github.com/TeskaLabs/asab-webui/commit/a0c35f567ff5b111f8be031195de4e70fa6e8e22))
 
+- Return multiplier in DateTime component (1000). It was deleted because of missunderstanding and it should stay because we use basic units (seconds). (INDIGO Sprint 210514, [!109](https://github.com/TeskaLabs/asab-webui/pull/109))
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - Create app descriptor on build (INDIGO Sprint 210430, [!108](https://github.com/TeskaLabs/asab-webui/pull/108))
 
+- Return DateTime multiplier for timestamp in seconds (by 1000) and add support of timestamp in milliseconds (INDIGO Sprint 210514, [!109](https://github.com/TeskaLabs/asab-webui/pull/109))
+
 ### Refactoring
 
 - Renaming configuration option FAKE_USERINFO to MOCK_USERINFO and refactoring code accordingly (INDIGO Sprint 210406, [!91](https://github.com/TeskaLabs/asab-webui/pull/91))
@@ -35,8 +37,6 @@
 - Make tenant an optional argument for `verify_access` method (INDIGO Sprint 210430, [!105](https://github.com/TeskaLabs/asab-webui/pull/105))
 
 - Delete multiplier in DateTime component in order to use proper timestamp (milliseconds) (INDIGO Sprint 210430, [a0c35f5](https://github.com/TeskaLabs/asab-webui/commit/a0c35f567ff5b111f8be031195de4e70fa6e8e22))
-
-- Return multiplier in DateTime component (1000). It was deleted because of missunderstanding and it should stay because we use basic units (seconds). (INDIGO Sprint 210514, [!109](https://github.com/TeskaLabs/asab-webui/pull/109))
 
 ### Bugfixes
 

--- a/src/containers/DateTime.js
+++ b/src/containers/DateTime.js
@@ -17,7 +17,7 @@ The input `value` is in UTC and one of:
 
 * Data() object (Javascript)
 * "2020-08-22T00:00:00+00:00" String with ISO format of the day
-* Number with Unix timestamp
+* Number with Unix timestamp (in seconds)
 
 The date&time will be converted to a local timezone of the browser.
 
@@ -35,7 +35,12 @@ export function DateTime(props) {
 		)
 	}
 
-	const m = moment(props.value);
+	let m = null;
+	if (isNaN(props.value)) {
+		m = moment(props.value);
+	} else {
+		m = moment(props.value * 1000.0);
+	}
 
 	return (
 		<span className="datetime" title={m.fromNow()}>

--- a/src/containers/DateTime.js
+++ b/src/containers/DateTime.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import moment from "moment";
 
 /*
@@ -17,7 +17,8 @@ The input `value` is in UTC and one of:
 
 * Data() object (Javascript)
 * "2020-08-22T00:00:00+00:00" String with ISO format of the day
-* Number with Unix timestamp (in seconds)
+* Number with Unix timestamp in seconds (max value is 9999999999)
+* Number with timestamp in milliseconds (min value is 10000000000)
 
 The date&time will be converted to a local timezone of the browser.
 
@@ -27,25 +28,21 @@ The default format is `lll` -> `Aug 22, 2020 1:13 PM`
 
 */
 
-export function DateTime(props) {
+export function DateTime({ value, format }) {
 
-	if ((props.value === null) || (props.value === undefined)) {
+	if ((value === null) || (value === undefined)) {
 		return (
 			<span className="datetime">{' '}</span>
 		)
 	}
 
-	let m = null;
-	if (isNaN(props.value)) {
-		m = moment(props.value);
-	} else {
-		m = moment(props.value * 1000.0);
-	}
+	const m = isNaN(value) ? moment(value) :
+		value.toString().length > 10 ? moment(value) : moment(value * 1000);
 
 	return (
 		<span className="datetime" title={m.fromNow()}>
 			<i className="cil-clock pr-1"></i>
-			{m.format(props.format || 'lll')}
+			{m.format(format || 'lll')}
 		</span>
 	)
 }

--- a/src/containers/DateTime.js
+++ b/src/containers/DateTime.js
@@ -36,8 +36,7 @@ export function DateTime({ value, format }) {
 		)
 	}
 
-	const m = isNaN(value) ? moment(value) :
-		value.toString().length > 10 ? moment(value) : moment(value * 1000);
+	const m = isNaN(value) || value > 9999999999 ? moment(value) : moment(value * 1000);
 
 	return (
 		<span className="datetime" title={m.fromNow()}>


### PR DESCRIPTION
Because of misunderstood I deleted multiplier by 1000 in DateTime component. On SCRUM meeting we decided that it should stay.

<img width="1440" alt="Screenshot 2021-05-17 at 14 49 52" src="https://user-images.githubusercontent.com/37152497/118491392-3ec68980-b71f-11eb-89b5-9613ed01eca6.png">
<img width="1440" alt="Screenshot 2021-05-17 at 14 50 05" src="https://user-images.githubusercontent.com/37152497/118491396-4128e380-b71f-11eb-9df6-521a4de984a4.png">

