### PR TITLE
Refactor change password link in the auth header dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 - Return DateTime multiplier for timestamp in seconds (by 1000) and add support of timestamp in milliseconds (INDIGO Sprint 210514, [!109](https://github.com/TeskaLabs/asab-webui/pull/109))
 
-- Add new features to datatable (buttonWithAuthz, action buttons, localization, sorting, spinner, ReactJSON adv mode below each row, fix zero in Footer, add classnames for DataTable components) (INDIGO Sprint 210430) [!107] (https://github.com/TeskaLabs/asab-webui/pull/107)
+- Add new features to datatable (buttonWithAuthz, action buttons, localization, sorting, spinner, ReactJSON adv mode below each row, fix zero in Footer, add classnames for DataTable components) (INDIGO Sprint 210430, [!107](https://github.com/TeskaLabs/asab-webui/pull/107))
 
 ### Refactoring
 
@@ -39,6 +39,8 @@
 - Make tenant an optional argument for `verify_access` method (INDIGO Sprint 210430, [!105](https://github.com/TeskaLabs/asab-webui/pull/105))
 
 - Delete multiplier in DateTime component in order to use proper timestamp (milliseconds) (INDIGO Sprint 210430, [a0c35f5](https://github.com/TeskaLabs/asab-webui/commit/a0c35f567ff5b111f8be031195de4e70fa6e8e22))
+
+- Update change password link of the Auth header dropdown based on creation of the new container with different route (`/change-password`) in SeaCat Auth WebUI (INDIGO Sprint 210528, [!115](https://github.com/TeskaLabs/asab-webui/pull/115))
 
 ### Bugfixes
 

--- a/src/modules/auth/header.js
+++ b/src/modules/auth/header.js
@@ -68,7 +68,7 @@ function HeaderComponent(props) {
 						<DropdownItem tag="a" href={user_auth_url}>
 							{t('AuthHeaderDropdown|Manage')}
 						</DropdownItem>
-						<DropdownItem tag="a" href={user_auth_url + '/#/pwd'}>
+						<DropdownItem tag="a" href={user_auth_url + '/#/change-password'}>
 							{t('AuthHeaderDropdown|Change a password')}
 						</DropdownItem>
 					</React.Fragment>


### PR DESCRIPTION
This PR refactor/update change password link of the Auth header dropdown based on creation of the new container with different route (`/change-password`) in SeaCat Auth WebUI.