### PR TITLE
Rename oidc service name to openidconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
 
 - Update change password link of the Auth header dropdown based on creation of the new container with different route (`/change-password`) in SeaCat Auth WebUI (INDIGO Sprint 210528, [!115](https://github.com/TeskaLabs/asab-webui/pull/115))
 
+- Rename `oidc` service name to `openidconnect` to align it with SeaCat Auth (INDIGO Sprint 210528, [!116](https://github.com/TeskaLabs/asab-webui/pull/116))
+
+
 ### Bugfixes
 
 - Update auth header dropdown and `Access control screen` to prevent app from crashing when tenant module is not enabled (INDIGO Sprint 210430, [!105](https://github.com/TeskaLabs/asab-webui/pull/105))

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ module.exports = {
 		BASE_URL: 'http://localhost:3000',
 		API_PATH: 'api',
 		SERVICES: {
-			oidc: 'openidconnect',
+			openidconnect: 'openidconnect',
 			asab_config: 'asab_config',
 			seacat_auth_webui: 'http://localhost:3000/auth'
 			}
@@ -159,7 +159,7 @@ module.exports = {
 		BASE_URL: 'https://example.com',
 		API_PATH: 'api',
 		SERVICES: {
-			oidc: 'openidconnect',
+			openidconnect: 'openidconnect',
 			asab_config: 'asab_config',
 			seacat_auth_webui: 'https://example.com/auth'
 			}

--- a/doc/devconfig.md
+++ b/doc/devconfig.md
@@ -45,7 +45,7 @@ module.exports = {
 		BASE_URL: 'http://localhost:3000',
 		API_PATH: 'api',
 		SERVICES: {
-			oidc: 'openidconnect',
+			openidconnect: 'openidconnect',
 			asab_config: 'asab_config',
 			seacat_auth_webui: 'http://localhost:3000/auth'
 			}

--- a/src/modules/auth/api.js
+++ b/src/modules/auth/api.js
@@ -12,7 +12,7 @@ export class SeaCatAuthApi {
 		app: {
 			BASE_URL: 'http://localhost:3000',
 			API_PATH: 'api',
-			SERVICES: {oidc: 'openidconnect', rbac: 'rbac'},
+			SERVICES: {openidconnect: 'openidconnect', rbac: 'rbac'},
 			...
 	*/
 
@@ -25,7 +25,7 @@ export class SeaCatAuthApi {
 		this.ClientId = "asab-webui-auth";
 		this.ClientSecret = "TODO";
 		this.SeaCatAuthAPI = this.App.axiosCreate('seacat_auth');
-		this.OidcAPI = this.App.axiosCreate('oidc');
+		this.OidcAPI = this.App.axiosCreate('openidconnect');
 
 	}
 
@@ -41,7 +41,7 @@ export class SeaCatAuthApi {
 			params.append("prompt", "login");
 		}
 
-		let oidcURL = this.App.getServiceURL('oidc');
+		let oidcURL = this.App.getServiceURL('openidconnect');
 		window.location.replace(oidcURL + "/authorize?" + params.toString());
 	}
 


### PR DESCRIPTION
This PR renames the `oidc` service to `openidconnect` to avoid mismatches with the SeaCat Auth.