### PR TITLE
Remove questionmark in hash URL when querystring is empty, lower alert timeout in DEV mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@
 
 - Return padding to DataTable because it looks better with it, refactor obtaining headers for DataTable from Configs because it should obtain them from inside applications, fix mistake in DataTable localization docs (INDIGO Sprint 210528, [!121](https://github.com/TeskaLabs/asab-webui/pull/121))
 
+- Replace questionmark in hash URL in initialization of the application when query string is empty (e.g. in provisioning mode, when in the starting point, there is no tenant) (INDIGO Sprint 210611, [!124](https://github.com/TeskaLabs/asab-webui/pull/124))
+
+- Set the DEV mode alert timeout to 3 seconds (INDIGO Sprint 210611, [!124](https://github.com/TeskaLabs/asab-webui/pull/124))
+
 ### Bugfixes
 
 - Update auth header dropdown and `Access control screen` to prevent app from crashing when tenant module is not enabled (INDIGO Sprint 210430, [!105](https://github.com/TeskaLabs/asab-webui/pull/105))

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -49,12 +49,16 @@ export default class AuthModule extends Module {
 			const authorization_code = qs.get('code');
 			if (authorization_code !== null) {
 				await this._updateToken(authorization_code);
-
 				// Remove 'code' from a query string
 				qs.delete('code');
 
+				// Check for empty query string and update hash url eventually
+				let hash_url = '?' + qs.toString() + window.location.hash;
+				if (qs.toString() == '') {
+					hash_url = '/' + qs.toString() + window.location.hash;
+				}
 				// And reload the app
-				window.location.replace('?' + qs.toString() + window.location.hash);
+				window.location.replace(hash_url);
 				return;
 			}
 

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -134,7 +134,7 @@ export default class AuthModule extends Module {
 			}
 
 		*/
-		this.App.addAlert("warning", "You are in DEV mode and using MOCK login parameters.", 60000);
+		this.App.addAlert("warning", "You are in DEV mode and using MOCK login parameters.", 3);
 		let mockParams = mock_userinfo;
 		if (mockParams.resources) {
 			mockParams["resources"] = Object.values(mockParams.resources)

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -55,7 +55,7 @@ export default class AuthModule extends Module {
 				// Check for empty query string and update hash url eventually
 				let hash_url = '?' + qs.toString() + window.location.hash;
 				if (qs.toString() == '') {
-					hash_url = '/' + qs.toString() + window.location.hash;
+					hash_url = '/' + window.location.hash;
 				}
 				// And reload the app
 				window.location.replace(hash_url);


### PR DESCRIPTION
This PR replace questionmark in hash URL in initialization of the application when query string is empty. It was causing troubles when e.g. no tenant has been obtained from userinfo (e.g. in provisioning mode) and thus the hash URL with qs looked like `?#/auth/credentials`. So here, when qs is an empty string, the `?` is replaced by `/` and thus result hash URL looks as following `/#/auth/credentials`.

The part of this PR is also lowering timeout of alert displaying `You are in DEV mode and using MOCK login parameters` when developer is in DEV mode to 3 seconds.