### PR TITLE
Add versioning to the styles.css file to avoid caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 - Implement function to remove item from Navigation (INDIGO Sprint 210611, [!117](https://github.com/TeskaLabs/asab-webui/pull/117))
 
+- Add versioning to the `styles.css` file on application build to avoid caching when redeploying the app to the production (INDIGO Sprint 210611, [!125](https://github.com/TeskaLabs/asab-webui/pull/125))
+>>>>>>> Update changelog
 
 ### Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Implement function to remove item from Navigation (INDIGO Sprint 210611, [!117](https://github.com/TeskaLabs/asab-webui/pull/117))
 
 - Add versioning to the `styles.css` file on application build to avoid caching when redeploying the app to the production (INDIGO Sprint 210611, [!125](https://github.com/TeskaLabs/asab-webui/pull/125))
->>>>>>> Update changelog
+
 
 ### Refactoring
 

--- a/webpack/webpack.build.js
+++ b/webpack/webpack.build.js
@@ -65,7 +65,7 @@ module.exports = {
 				),
 				// Extracts file styles.css
 				new ExtractTextPlugin({
-					filename: 'assets/css/styles.css',
+					filename: 'assets/css/styles.[chunkhash:8].css',
 					allChunks: true
 				}),
 				new UglifyJsPlugin({


### PR DESCRIPTION
This PR add a versioning to `style.css` file to aviod caching when redeploying new version of app to the production