### PR TITLE
Refactor capitalization of authorization configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 
 - Refactor obtaining formats for format items in ASAB-Config module. It seek for `$defs` key to generate appropriate input type. (INDIGO Sprint 210528, [!103](https://github.com/TeskaLabs/asab-webui/pull/103))
 
+- Refactor capitalization of authorization configuration in the config file. (INDIGO Sprint 210611, [!128](https://github.com/TeskaLabs/asab-webui/pull/128))
 
 
 ### Bugfixes

--- a/doc/authorization.md
+++ b/doc/authorization.md
@@ -24,13 +24,13 @@ Only tenants authorized for the user are displayed.
 
 ### Setup
 
-In the top-level `index.js` of your ASAB UI application, load the Tenant module and add to ConfigDefaults `Authorization` with keys and values.
+In the top-level `index.js` of your ASAB UI application, load the Tenant module and add to ConfigDefaults `authorization` with keys and values.
 
-`Authorize` must be set to `true` to enable the feature
+`authorize` must be set to `true` to enable the feature
 
-`Resource` is used for setting up resource for `rbac` endpoint. By default is set to `tenant:access`
+`resource` is used for setting up resource for `rbac` endpoint. By default is set to `tenant:access`
 
-`UnauthorizedLogoutTimeout` is a timeout period on which the screen will stay in SplashScreen mode before it log out the unauthorized user. Default value is 60000 aka 60s.
+`unauthorized_logout_timeout` is a timeout period on which the screen will stay in SplashScreen mode before it log out the unauthorized user. Default value is 60000 aka 60s.
 
 <!-- TODO: Set up also BASE_URL, Microservice, Subpaths, etc... -->
 
@@ -43,7 +43,7 @@ import TenantModule from 'asab-webui/modules/tenant';
 modules.push(TenantModule);
 
 let ConfigDefaults = {
-	Authorization: { Authorize: true, Resource: "tenant:access", UnauthorizedLogoutTimeout: 60000},
+	authorization: { authorize: true, resource: "tenant:access", unauthorized_logout_timeout: 60000},
 };
 
 ...

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -23,8 +23,7 @@ export default class AuthModule extends Module {
 		this.App.addSplashScreenRequestor(this);
 
 		this.Navigation = app.Navigation; // Get the navigation
-		this.Authorization = this.Config.get("Authorization"); // Get Authorization settings from configuration
-
+		this.Authorization = this.Config.get("authorization"); // Get authorization settings from configuration
 
 		// Access control screen
 		app.Router.addRoute({
@@ -80,10 +79,10 @@ export default class AuthModule extends Module {
 				this.App.addAxiosInterceptor(this.authInterceptor());
 
 				// Authorization of the user based on tenant access
-				if (this.Authorization?.Authorize) {
+				if (this.Authorization?.authorize) {
 					// Tenant access validation
-					let tenant_authorized = await this._isUserAuthorized(this.Authorization?.Resource, this.App.Services.TenantService);
-					let logoutTimeout = this.Authorization?.UnauthorizedLogoutTimeout ? this.Authorization.UnauthorizedLogoutTimeout : 60000;
+					let tenant_authorized = await this._isUserAuthorized(this.Authorization?.resource, this.App.Services.TenantService);
+					let logoutTimeout = this.Authorization?.unauthorized_logout_timeout ? this.Authorization.unauthorized_logout_timeout : 60000;
 					if (!tenant_authorized) {
 						this.App.addAlert("danger", "You are not authorized to use this application.", logoutTimeout);
 						// Logout after some time

--- a/src/modules/tenant/service.js
+++ b/src/modules/tenant/service.js
@@ -50,9 +50,9 @@ export default class TenantService extends Service {
 		if (tenants_list) {
 			let filtered_tenant = tenants_list.filter((item) => { return item == tenant_id });
 			if (filtered_tenant.length < 1) {
-				// Display Invalid tenant alert message only when Authorization is disabled
-				let authorization = this.App.Config.get("Authorization");
-				if (!authorization?.Authorize) {
+				// Display Invalid tenant alert message only when authorization is disabled
+				let authorization = this.App.Config.get("authorization");
+				if (!authorization?.authorize) {
 					this.App.addAlert("danger", "Invalid tenant :-(", 40000);
 				}
 				return;


### PR DESCRIPTION
- This PR remove capitalization in config files when setting up the `authorization` setting to preserve the config file structure

Previously the setting would be:

```
let ConfigDefaults = {
	Authorization: { Authorize: true, Resource: "tenant:access", UnauthorizedLogoutTimeout: 60000}
}
```

now it is:

```
let ConfigDefaults = {
	authorization: { authorize: true, resource: "tenant:access", unauthorized_logout_timeout: 60000}
}
```