### PR TITLE
Refactor/access control screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@
 
 - Refactor the ASAB-Config configuration with better look - the content of the config is now available to display and change in JSON form, the whole displayed config is wrapped in a Card. (INDIGO Sprint 210625, [!129](https://github.com/TeskaLabs/asab-webui/pull/129))
 
+- Refactor Access control screen of `auth` module - Back to previous screen option has been removed, bullet points for multiple Roles and Resources has been removed, tenant name has been changed. (INDIGO Sprint 210625, [!134](https://github.com/TeskaLabs/asab-webui/pull/134))
+
 
 ### Bugfixes
 

--- a/doc/access-control.md
+++ b/doc/access-control.md
@@ -1,0 +1,21 @@
+# Access control screen
+
+Access control screen is a part of a `auth` module dropdown and it display the information about user rights and accesses.
+
+## Language localisations
+
+Language localizations for AccessControlScreen can be added to the translation.json files of `public/locales/en` & `public/locales/cs` of the product where AccessControlScreen component is used.
+
+Example:
+
+```
+{
+	"AccessControlScreen": {
+		"Access control": "Access control",
+		"See your details": "You can see your access permissions here",
+		"Tenant": "Tenant",
+		"Roles": "Roles",
+		"Resources": "Resources"
+	}
+}
+```

--- a/doc/asab-config.md
+++ b/doc/asab-config.md
@@ -55,3 +55,30 @@ ReactDOM.render((
 	</HashRouter>
 ), document.getElementById('app'));
 ```
+
+## Language localisations
+
+Language localizations for ASAB-Config configuration can be added to the translation.json files of `public/locales/en` & `public/locales/cs` of the product where ASAB Config module is used.
+
+Example:
+
+```
+{
+	"ASABConfig" : {
+		"Nothing has been selected yet": "Nothing has been selected yet",
+		"Please select the configuration from tree menu on the left side of the screen": "Please select the configuration from tree menu on the left side of the screen",
+		"Save": "Save",
+		"Read only": "Read only",
+		"Basic": "Basic",
+		"Advanced": "Advanced",
+		"Data updated successfuly": "Data updated successfuly",
+		"Something went wrong": "Something went wrong!",
+		"We are sorry, but the file cannot be found": "We are sorry, but the file cannot be found :-(",
+		"Config file does not exist": "Config file does not exist",
+		"Something went wrong! Unable to get data": "Something went wrong! Unable to get {{type}} data",
+		"Unable to get types": "Unable to get types",
+		"Unable to get type data. Try to reload the page": "Unable to get type {{type}} data. Try to reload the page",
+		"Unable to get config data. Try to reload the page": "Unable to get config {{config}} data. Try to reload the page"
+	}
+}
+```

--- a/src/modules/auth/AccessControlScreen.js
+++ b/src/modules/auth/AccessControlScreen.js
@@ -72,7 +72,7 @@ function AccessControlCard(props) {
 								<h5>{t('AccessControlScreen|Tenant')}</h5>
 							</Col>
 							<Col>
-								{currentTenant}
+								<p style={{marginBottom: "5px"}}>{currentTenant}</p>
 							</Col>
 						</Row>
 						<hr/>

--- a/src/modules/auth/AccessControlScreen.js
+++ b/src/modules/auth/AccessControlScreen.js
@@ -20,10 +20,9 @@ import {
 		"AccessControlScreen": {
 			"Access control": "Access control",
 			"See your details": "You can see your access permissions here",
-			"Current tenant": "Current tenant",
+			"Tenant": "Tenant",
 			"Roles": "Roles",
-			"Resources": "Resources",
-			"Previous screen": "Back to previous screen"
+			"Resources": "Resources"
 		}
 	}
 
@@ -70,12 +69,10 @@ function AccessControlCard(props) {
 					<React.Fragment>
 						<Row>
 							<Col>
-								<h5>{t('AccessControlScreen|Current tenant')}</h5>
+								<h5>{t('AccessControlScreen|Tenant')}</h5>
 							</Col>
 							<Col>
-								<ul style={{padding: 0}}>
-									<li>{currentTenant}</li>
-								</ul>
+								{currentTenant}
 							</Col>
 						</Row>
 						<hr/>
@@ -95,24 +92,6 @@ function AccessControlCard(props) {
 					<ItemToRender userinfo={userinfo} item='resources' />
 				</Row>
 			</CardBody>
-			<CardFooter>
-				<Row className="justify-content-center">
-					<Col>
-						<Button
-							size="sm"
-							outline
-							block
-							color="link"
-							type="button"
-							onClick={() => history.goBack()}
-						>
-							<i className="cil-arrow-thick-left"></i>
-							{' '}
-							{t("AccessControlScreen|Previous screen")}
-						</Button>
-					</Col>
-				</Row>
-			</CardFooter>
 		</Card>
 		)
 }
@@ -122,15 +101,13 @@ function ItemToRender(props) {
 	let item = props.item;
 	return(
 		<Col>
-			<ul style={{padding: 0}}>
 			{props.userinfo[item] ?
 				props.userinfo[item].map(itm => {
-					return(<li key={itm}>{itm}</li>)
+					return(<p style={{marginBottom: "5px"}} key={itm}>{itm}</p>)
 				})
 				:
 				null
 			}
-			</ul>
 		</Col>
 		)
 }


### PR DESCRIPTION
This PR refactor AccessControl Screen of Auth module
- Renamed Current tenant to Tenant
- Removed `Back to previous screen` option in footer
- Removed bullet points
- Added a documentation for AccessControl Screen

Among those changes, the update of ASAB-Config documentation has been processed

![Selection_246](https://user-images.githubusercontent.com/45622755/124782952-f3717000-df44-11eb-90eb-49198bc8bb33.png)
![Selection_245](https://user-images.githubusercontent.com/45622755/124782956-f4a29d00-df44-11eb-9b64-c6ed522a8b7b.png)


