### PR TITLE
Fix AccessControlScreen when userinfo is null (after expired session)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,3 +87,5 @@
 - Fix paths to language locales when app is build on subpath (INDIGO Sprint 210611, [!126](https://github.com/TeskaLabs/asab-webui/pull/126))
 
 - Fix URL of Access control screen and SeaCat Auth WebUI when app is build on subpath (INDIGO Sprint 210611, [!126](https://github.com/TeskaLabs/asab-webui/pull/126))
+
+- Fix AccessControlScreen behaviour if userinfo is null (INDIGO Sprint 210625, [!136](https://github.com/TeskaLabs/asab-webui/pull/136))

--- a/src/modules/auth/AccessControlScreen.js
+++ b/src/modules/auth/AccessControlScreen.js
@@ -48,7 +48,6 @@ function AccessControlCard(props) {
 	const { t, i18n } = useTranslation();
 	let history = useHistory();
 	let userinfo = props.userinfo;
-	
 	let App = props.app;
 	let currentTenant;
 	// Check Tenant service availability

--- a/src/modules/auth/AccessControlScreen.js
+++ b/src/modules/auth/AccessControlScreen.js
@@ -48,6 +48,7 @@ function AccessControlCard(props) {
 	const { t, i18n } = useTranslation();
 	let history = useHistory();
 	let userinfo = props.userinfo;
+	
 	let App = props.app;
 	let currentTenant;
 	// Check Tenant service availability
@@ -65,32 +66,40 @@ function AccessControlCard(props) {
 			</CardHeader>
 
 			<CardBody>
-				{App.Services.TenantService &&
-					<React.Fragment>
+				{ userinfo ? (
+					<>
+						{App.Services.TenantService &&
+							<React.Fragment>
+								<Row>
+									<Col>
+										<h5>{t('AccessControlScreen|Tenant')}</h5>
+									</Col>
+									<Col>
+										<p style={{marginBottom: "5px"}}>{currentTenant}</p>
+									</Col>
+								</Row>
+								<hr/>
+							</React.Fragment>
+						}
 						<Row>
 							<Col>
-								<h5>{t('AccessControlScreen|Tenant')}</h5>
+								<h5>{t('AccessControlScreen|Roles')}</h5>
 							</Col>
-							<Col>
-								<p style={{marginBottom: "5px"}}>{currentTenant}</p>
-							</Col>
+							<ItemToRender userinfo={userinfo} item='roles' />
 						</Row>
 						<hr/>
-					</React.Fragment>
-				}
-				<Row>
-					<Col>
-						<h5>{t('AccessControlScreen|Roles')}</h5>
-					</Col>
-					<ItemToRender userinfo={userinfo} item='roles' />
-				</Row>
-				<hr/>
-				<Row>
-					<Col>
-						<h5>{t('AccessControlScreen|Resources')}</h5>
-					</Col>
-					<ItemToRender userinfo={userinfo} item='resources' />
-				</Row>
+						<Row>
+							<Col>
+								<h5>{t('AccessControlScreen|Resources')}</h5>
+							</Col>
+							<ItemToRender userinfo={userinfo} item='resources' />
+						</Row>
+					</>
+					) : (
+					<div className="text-center">
+						<h5>{t("AccessControlScreen|UserInfo doesn't exist.")}</h5>
+					</div>
+				)}
 			</CardBody>
 		</Card>
 		)

--- a/src/modules/auth/AccessControlScreen.js
+++ b/src/modules/auth/AccessControlScreen.js
@@ -96,7 +96,7 @@ function AccessControlCard(props) {
 					</>
 					) : (
 					<div className="text-center">
-						<h5>{t("AccessControlScreen|UserInfo doesn't exist.")}</h5>
+						<h5>{t("AccessControlScreen|The user information is invalid, you session is likely expired.")}</h5>
 					</div>
 				)}
 			</CardBody>

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -201,7 +201,7 @@ export default class AuthModule extends Module {
 				const alertMessage = await that.App.i18n.t("Your session has expired");
 				that.App.addAlert("warning", alertMessage);
 			}
-			that.UserInfo = null;
+			if (!oldUserInfo) that.UserInfo = null;
 			if (that.App.Store != null) {
 				that.App.Store.dispatch({ type: types.AUTH_USERINFO, payload: that.UserInfo });
 			}

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -201,7 +201,7 @@ export default class AuthModule extends Module {
 				const alertMessage = await that.App.i18n.t("Your session has expired");
 				that.App.addAlert("warning", alertMessage);
 			}
-			if (!oldUserInfo) that.UserInfo = null;
+			that.UserInfo = null;
 			if (that.App.Store != null) {
 				that.App.Store.dispatch({ type: types.AUTH_USERINFO, payload: that.UserInfo });
 			}


### PR DESCRIPTION
I suppose that this solution is better in case when session has expired rather than keep old userinfo b/c in that case user can't see any info after session has expired.
 
 <img width="1440" alt="Screenshot 2021-07-08 at 4 05 17" src="https://user-images.githubusercontent.com/37152497/124851127-36adfc00-dfa2-11eb-9ef7-cef68f3e02a1.png">
