### PR TITLE
AboutScreen — Hide row with empty version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,8 @@
 
 - Add a possibility to add icons to items of ActionButton component of DataTable (INDIGO Sprint 210903, [!173](https://github.com/TeskaLabs/asab-webui/pull/173))
 
+- Hide a row with version in UserInterface card, when there is no version provided (INDIGO Sprint 210903, [!171](https://github.com/TeskaLabs/asab-webui/pull/171))
+
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@
 
 - Add a possibility to add icons to items of ActionButton component of DataTable (INDIGO Sprint 210903, [!173](https://github.com/TeskaLabs/asab-webui/pull/173))
 
-- Hide a row with version in UserInterface card, when there is no version provided (INDIGO Sprint 210903, [!171](https://github.com/TeskaLabs/asab-webui/pull/171))
+- Hide rows with version in UserInterfaceCard and with website in AboutCard of about module, when they are not provided (INDIGO Sprint 210903, [!171](https://github.com/TeskaLabs/asab-webui/pull/171))
 
 
 ### Bugfixes

--- a/src/modules/about/AboutCard.js
+++ b/src/modules/about/AboutCard.js
@@ -46,17 +46,21 @@ function AboutCard(props) {
 						{vendor}
 					</Col>
 				</Row>
-				<hr/>
-				<Row>
-					<Col>
-						<h5>{t('AboutCard|Website')}</h5>
-					</Col>
-					<Col>
-						<a href={website} target="_blank" rel="noopener noreferrer">
-							{website}
-						</a>
-					</Col>
-				</Row>
+				{ website &&
+					<React.Fragment>
+						<hr/>
+						<Row>
+							<Col>
+								<h5>{t('AboutCard|Website')}</h5>
+							</Col>
+							<Col>
+								<a href={website} target="_blank" rel="noopener noreferrer">
+									{website}
+								</a>
+							</Col>
+						</Row>
+					</React.Fragment>
+				}
 				<hr/>
 				<Row>
 					<Col></Col>

--- a/src/modules/about/UserInterfaceCard.js
+++ b/src/modules/about/UserInterfaceCard.js
@@ -36,15 +36,19 @@ function UserInterfaceCard() {
 				<h1>{t('UserInterfaceCard|User interface')}</h1>
 			</CardHeader>
 			<CardBody>
-				<Row>
-					<Col>
-						<h5>{t('UserInterfaceCard|Version')}</h5>
-					</Col>
-					<Col>
-						{version}
-					</Col>
-				</Row>
-				<hr/>
+				{version &&
+					<React.Fragment>
+						<Row>
+							<Col>
+								<h5>{t('UserInterfaceCard|Version')}</h5>
+							</Col>
+							<Col>
+								{version}
+							</Col>
+						</Row>
+						<hr/>
+					</React.Fragment>
+				}
 				<Row>
 					<Col>
 						<h5>{t('UserInterfaceCard|Build date')}</h5>

--- a/src/modules/about/UserInterfaceCard.js
+++ b/src/modules/about/UserInterfaceCard.js
@@ -36,7 +36,7 @@ function UserInterfaceCard() {
 				<h1>{t('UserInterfaceCard|User interface')}</h1>
 			</CardHeader>
 			<CardBody>
-				{version &&
+				{ version &&
 					<React.Fragment>
 						<Row>
 							<Col>


### PR DESCRIPTION
Hide a row with the version in UserInterface card, when there is no version provided

![hide-version](https://user-images.githubusercontent.com/57274895/133243958-efc89828-f7ba-49f2-8717-17633901b4c8.png)
