### PR TITLE
Filter those breadcrumbs items which doesn't have names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,3 +197,5 @@
 - Throw error for undefined response in MicroservicesListContainer (INDIGO Sprint 211029, [!189](https://github.com/TeskaLabs/asab-webui/pull/189))
 
 - Fix mock userinfo in dev locale (INDIGO Sprint 211029, [!191](https://github.com/TeskaLabs/asab-webui/pull/191))
+
+- Fix breadcrumbs for dynamic routes or crumbs which doesn't have name (INDIGO Sprint 211029, [!196](https://github.com/TeskaLabs/asab-webui/pull/196))

--- a/doc/breadcrumbs.md
+++ b/doc/breadcrumbs.md
@@ -1,0 +1,9 @@
+# Translating breadcrumbs
+
+Breadcrumbs automatically add translating function with key `Breadcrumbs` to crumb name. In order to create translation just add into your `translation.json` files `Breadcrumbs` block and inside add definitions your translations:
+
+```
+"Breadcrumbs": {
+	"crumb": "drobek"
+}
+```

--- a/src/containers/Breadcrumbs.js
+++ b/src/containers/Breadcrumbs.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { useRouteMatch, useLocation, Link } from 'react-router-dom';
+import React from 'react';
+import { Link } from 'react-router-dom';
 
 import { Breadcrumb, BreadcrumbItem } from 'reactstrap';
 
@@ -13,25 +13,24 @@ const Breadcrumbs = ({ routes, match }) => {
 					path.replace(`:${param}`, match.params[param]), path
 				) : path,
 				...rest
-		}));
+		})).
+		filter(crumb => crumb.name);
 
 	return (
 		<>
-			{crumbs.length > 1 && 
-				<div className="breadcrumbs">
-					<Breadcrumb>
-						{crumbs.map((crumb, idx) => (
-							<BreadcrumbItem key={idx} active={idx === crumbs.length - 1}>
-								{idx !== crumbs.length - 1 ? 
-									<Link to={crumb.path}>{crumb.name}</Link>
-									: <span>{crumb.name}</span>
-								}
-							</BreadcrumbItem>
-						))
-						}
-					</Breadcrumb>
-				</div>
-			}
+			<div className="breadcrumbs">
+				<Breadcrumb>
+					{crumbs.map((crumb, idx) => (
+						<BreadcrumbItem key={idx} active={idx === crumbs.length - 1}>
+							{idx !== crumbs.length - 1 ? 
+								<Link to={crumb.path}>{crumb.name}</Link>
+								: <span>{crumb.name}</span>
+							}
+						</BreadcrumbItem>
+					))
+					}
+				</Breadcrumb>
+			</div>
 		</>
 	)
 }

--- a/src/containers/Breadcrumbs.js
+++ b/src/containers/Breadcrumbs.js
@@ -1,9 +1,12 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
+import { Link } from 'react-router-dom';
 import { Breadcrumb, BreadcrumbItem } from 'reactstrap';
 
+
 const Breadcrumbs = ({ routes, match }) => {
+	const { t } = useTranslation();
 
 	// Get new crumbs each time location has been changed
 	const crumbs = routes.filter(({ path }) => match.path.includes(path)).
@@ -25,8 +28,8 @@ const Breadcrumbs = ({ routes, match }) => {
 					{crumbs.map((crumb, idx) => (
 						<BreadcrumbItem key={idx} active={idx === crumbs.length - 1}>
 							{idx !== crumbs.length - 1 ? 
-								<Link to={crumb.path}>{crumb.name}</Link>
-								: <span>{crumb.name}</span>
+								<Link to={crumb.path}>{t(`Breadcrumbs|${crumb.name}`)}</Link>
+								: <span>{t(`Breadcrumbs|${crumb.name}`)}</span>
 							}
 						</BreadcrumbItem>
 					))

--- a/src/containers/Breadcrumbs.js
+++ b/src/containers/Breadcrumbs.js
@@ -16,6 +16,8 @@ const Breadcrumbs = ({ routes, match }) => {
 		})).
 		filter(crumb => crumb.name);
 
+	if (crumbs.length == 0) return null;
+
 	return (
 		<>
 			<div className="breadcrumbs">


### PR DESCRIPTION
CHANGES:
- Now items which doesn't have names won't be rendered in breadcrumbs (e.g. library container).
- Also breadcrumbs with only one item will be rendered. (e.g. export container)
- When there no items in breadcrumbs (e.g. when all routes in breadcrumbs doesn't have names) then breadcrumbs container won't be rendered

<img width="1430" alt="Screenshot 2021-11-04 at 23 16 55" src="https://user-images.githubusercontent.com/37152497/140429174-68adacbf-6c17-44dc-8ec2-872ee2d19fac.png">
<img width="1430" alt="Screenshot 2021-11-04 at 23 18 58" src="https://user-images.githubusercontent.com/37152497/140429181-c4216195-bca0-4f27-a0cb-6be50cefd93d.png">
<img width="1430" alt="Screenshot 2021-11-04 at 23 20 37" src="https://user-images.githubusercontent.com/37152497/140429183-c7d3ea39-10b2-4bd6-9358-1f57521f53c5.png">
