### PR TITLE
Uncollapse Sidebar Items if needed and new ordering of items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@
 
 - Add ErrorHandler (ErrorBoundaries component) (INDIGO Sprint 211015, [!186](https://github.com/TeskaLabs/asab-webui/pull/186))
 
+- Uncollapse sidebar items when in sidebar there 2 or less items + Uncollapse active sidebar item + New ordering of sidebar items (INDIGO Sprint 211029, [!201](https://github.com/TeskaLabs/asab-webui/pull/201))
+
 ### Refactoring
 
 - Renaming configuration option FAKE_USERINFO to MOCK_USERINFO and refactoring code accordingly (INDIGO Sprint 210406, [!91](https://github.com/TeskaLabs/asab-webui/pull/91))

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -2,49 +2,18 @@
 
 ## Changing order of sidebar navigation items
 
-It is possible to change order of sidebar navigation items when you add items to Navigation. Just add `order` property with number value to object which you pass into `app.Navigation.addItem()` and sidebar items will be automatically sorted from smallest to highest: 
+It is possible to change order of sidebar navigation items. Just add `sidebarItemsOrder` prop to Application component with value of Array of strings (each string represent sidebar item name) and sidebar items will be automatically sorted by this `sidebarItemsOrder` array (all items which are not listed in the array will just be added at the bottom of sidebar items list):
 
 ```
-	app.Navigation.addItem({
-		name: 'Nowhere',
-		url: '/nowhere',
-		icon: 'cil-casino',
-		order: 3
-	});
-
-	app.Navigation.addItem({
-		name: 'Wrapped',
-		icon: 'cil-chart',
-		order: 1,
-		children: [
-			{
-				name: 'Home',
-				url: '/',
-				icon: 'cil-home',
-			},
-			{
-				name: 'Table',
-				url: '/Table',
-				icon: 'cil-chart',
-			}
-		]
-	});
-
-	app.Navigation.addItem({
-		name: 'Fancy',
-		url: '/fancy',
-		icon: 'cil-copy',
-		order: 2
-	})
-
+	const sidebarItemsOrder = ["Auth", "Discover", "Tools"]
+	...
+	<Application
+		sidebarItemsOrder={sidebarItemsOrder}
+		configdefaults={ConfigDefaults}
+		modules={modules}
+		defaultpath={__CONFIG__.defaultpath ? __CONFIG__.defaultpath : "/"}
+	/>
 ```
-
-This will show items in sidebar in order:
-1) Wrapped
-2) Fancy
-3) Nowhere
-
-Note: `order` property can be either number or string which can be parsed as number (i.e. `2` or `"2"`). If `order` property is `undefined` or value is set incorrect (i.e. `"2a"`) then sidebar will count such item for `9999` and such item will take place at the bottom of the sidebar navigation items list.
 
 ## Setting resource for sidebar item
 

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -28,15 +28,13 @@ The resource is set to the navigation `addItem` component.
 		name: 'Nowhere',
 		url: '/nowhere',
 		icon: 'cil-casino',
-		resource: 'nowhere:access',
-		order: 3
+		resource: 'nowhere:access'
 	});
 
 	app.Navigation.addItem({
 		name: 'Wrapped',
 		icon: 'cil-chart',
-		resource: 'wrapped:access',
-		order: 1,
+		resource: 'wrapped:access'
 		children: [
 			{
 				name: 'Home',
@@ -54,8 +52,7 @@ The resource is set to the navigation `addItem` component.
 	app.Navigation.addItem({
 		name: 'Fancy',
 		url: '/fancy',
-		icon: 'cil-copy',
-		order: 2
+		icon: 'cil-copy'
 	})
 
 ```
@@ -72,8 +69,7 @@ The resource is set to the navigation `addItem` -> `children` component.
 	app.Navigation.addItem({
 		name: 'Wrapped',
 		icon: 'cil-chart',
-		resource: 'wrapped:access',
-		order: 1,
+		resource: 'wrapped:access'
 		children: [
 			{
 				name: 'Home',

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -512,7 +512,6 @@ it is accessible by the sidebar toggler button.
 										navigation={this.Navigation}
 										display="lg"
 										sidebarItemsOrder={this.props.sidebarItemsOrder}
-
 									/>
 							}
 							<Main hasSidebar={this.props.hasSidebar}>

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -507,7 +507,13 @@ it is accessible by the sidebar toggler button.
 						<div className="app-body">
 							{
 								(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') &&
-									<Sidebar app={this} navigation={this.Navigation} display="lg" />
+									<Sidebar
+										app={this}
+										navigation={this.Navigation}
+										display="lg"
+										sidebarItemsOrder={this.props.sidebarItemsOrder}
+
+									/>
 							}
 							<Main hasSidebar={this.props.hasSidebar}>
 								<Suspense

--- a/src/containers/Sidebar/SidebarItem.js
+++ b/src/containers/Sidebar/SidebarItem.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLocation, useHistory } from 'react-router';
 import { useTranslation } from 'react-i18next';
 
@@ -8,7 +8,7 @@ import {
 
 import Icon from './SidebarIcon';
 
-const SidebarItem = ({ item, unauthorizedNavChildren }) => {
+const SidebarItem = ({ item, unauthorizedNavChildren, uncollapseAll }) => {
 	const [isOpen, setOpen] = useState(false);
 
 	const location = useLocation();
@@ -16,14 +16,38 @@ const SidebarItem = ({ item, unauthorizedNavChildren }) => {
 
 	const { t } = useTranslation();
 
+	// Should collapsed item uncollapse
+	useEffect(() => {
+		if (item.children) {
+			// if length of all sidebar items is 2 or less
+			if (uncollapseAll) {
+				setOpen(true);
+				return;
+			}
+
+			// if child is active
+			item.children.forEach(child => {
+				if (child.url === location.pathname) {
+					setOpen(true);
+				}
+			});
+		}
+	}, []);
+
+	 const onNavLink = () => {
+		// Preserve from history pushing when item.url doesn't exist
+		// or when current location pathname is the same as item.url
+		if (item.url && location.pathname !== item.url) history.push(item.url);
+		// Preserve from collapsing when item doesn't have children
+		// or if item should always be uncollapsed
+		else if (item.children && !uncollapseAll) setOpen(prev => !prev);
+	}
+
 	return (
-		<NavItem className={`${item.children ? "sidebar-dropdown" : ""} ${isOpen ? "sidebar-dropdown-open": ""}`}>
+		<NavItem className={`${item.children ? "sidebar-dropdown" : "sidebar-item"} ${isOpen ? "sidebar-dropdown-open": ""}`}>
 			<NavLink
 				className={`${location.pathname === item.url ? "active" : ""}`}
-				onClick={() => {
-					if (item.url && location.pathname !== item.url) history.push(item.url);
-					if (item.children) setOpen(prev => !prev);
-				}}
+				onClick={onNavLink}
 			>
 				<Icon icon={item.icon} />
 				<span className="sidebar-item-text">{t(`Sidebar|${item.name}`)}</span>

--- a/src/containers/Sidebar/index.js
+++ b/src/containers/Sidebar/index.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { connect } from 'react-redux';
 
-import { Nav, Button } from 'reactstrap';
+import { Nav } from 'reactstrap';
 import SidebarItem from './SidebarItem';
 
 import { CHANGE_SIDEBAR_SIZE } from '../../actions';
@@ -14,11 +14,18 @@ const Sidebar = (props) => {
 
 	// Sort items based on config
 	const memoizedItemsList = useMemo(() => {
-		const itemsList = [...navConfig].sort((a,b) => {
-			const aOrder = isNaN(a.order) ? 9999 : a.order,
-				bOrder = isNaN(b.order) ? 9999 : b.order;
-			return aOrder > bOrder ? 1 : -1;
-		});
+		let itemsList = [...navConfig]
+		if (props.sidebarItemsOrder) {
+			const sidebarItemsOrder = props.sidebarItemsOrder.reverse();
+			itemsList.sort((a, b) => {
+				if (sidebarItemsOrder.indexOf(a.name) > sidebarItemsOrder.indexOf(b.name)) return -1;
+				else return 1;
+			});
+		}
+
+		if (unauthorizedNavItems != undefined || unauthorizedNavItems.length != 0) {
+			itemsList = itemsList.filter((item) => unauthorizedNavItems.indexOf(item.name) == -1);
+		}
 
 		return itemsList;
 	}, [navConfig])
@@ -30,10 +37,12 @@ const Sidebar = (props) => {
 			<div className="sidebar-nav">
 				<Nav  vertical>
 					{memoizedItemsList.map((item, idx) => (
-						unauthorizedNavItems == undefined || unauthorizedNavItems.length == 0 ?
-							<SidebarItem item={item} unauthorizedNavChildren={unauthorizedNavChildren} key={idx}/>
-						:
-							unauthorizedNavItems.indexOf(item.name) == -1 && <SidebarItem item={item} unauthorizedNavChildren={unauthorizedNavChildren} key={idx}/>
+						<SidebarItem
+							key={idx}
+							item={item}
+							unauthorizedNavChildren={unauthorizedNavChildren}
+							uncollapseAll={memoizedItemsList.length <= 2}
+						/>
 					))}
 				</Nav>
 				<div className="sidebar-bottom">


### PR DESCRIPTION
CHANGES:
- Uncollapse collapsed sidebar items when in sidebar there are 2 or less items
- Uncollapse active sidebar item when page is reloaded
- New ordering of sidebar items based on array from Application props

<img width="1440" alt="Screenshot 2021-11-08 at 17 33 52" src="https://user-images.githubusercontent.com/37152497/140781183-d7043c09-7339-4812-a99a-992ddb4c9509.png">
<img width="1440" alt="Screenshot 2021-11-08 at 17 28 48" src="https://user-images.githubusercontent.com/37152497/140781225-341d4dbb-5f0d-43bb-82f8-d2bea9c25eef.png">
