### PR TITLE
Refactor/add email title to about card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,8 @@
 
 - Adds i18n translations to alert messages (INDIGO Sprint 211029, [!203](https://github.com/TeskaLabs/asab-webui/pull/203))
 
+- Adds missing email title to AboutCard module (INDIGO Spring 211112, [!205](https://github.com/TeskaLabs/asab-webui/pull/205))
+
 ### Bugfixes
 
 - Update auth header dropdown and `Access control screen` to prevent app from crashing when tenant module is not enabled (INDIGO Sprint 210430, [!105](https://github.com/TeskaLabs/asab-webui/pull/105))

--- a/src/modules/about/AboutCard.js
+++ b/src/modules/about/AboutCard.js
@@ -31,8 +31,6 @@ function AboutCard(props) {
 	const website = App.Config.get("website");
 	const email = App.Config.get("email");
 
-
-
 	return(
 		<Card className="shadow animated fadeIn">
 			<CardHeader className="text-center">

--- a/src/modules/about/AboutCard.js
+++ b/src/modules/about/AboutCard.js
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {

--- a/src/modules/about/AboutCard.js
+++ b/src/modules/about/AboutCard.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -31,6 +31,8 @@ function AboutCard(props) {
 	const website = App.Config.get("website");
 	const email = App.Config.get("email");
 
+
+
 	return(
 		<Card className="shadow animated fadeIn">
 			<CardHeader className="text-center">
@@ -61,13 +63,19 @@ function AboutCard(props) {
 						</Row>
 					</React.Fragment>
 				}
-				<hr/>
-				<Row>
-					<Col></Col>
-					<Col>
-						<a href={`mailto:${email}`}>{email}</a>
-					</Col>
-				</Row>
+				{ email &&
+					<React.Fragment>
+						<hr/>
+						<Row>
+							<Col>
+								<h5>{t('AboutCard|Email')}</h5>
+							</Col>
+							<Col>
+								<a href={`mailto:${email}`}>{email}</a>
+							</Col>
+						</Row>
+				</React.Fragment>
+				}
 			</CardBody>
 		</Card>
 	)

--- a/src/modules/about/AboutCard.js
+++ b/src/modules/about/AboutCard.js
@@ -68,7 +68,7 @@ function AboutCard(props) {
 						<hr/>
 						<Row>
 							<Col>
-								<h5>{t('AboutCard|Email')}</h5>
+								<h5>Email</h5>
 							</Col>
 							<Col>
 								<a href={`mailto:${email}`}>{email}</a>


### PR DESCRIPTION
Adds missing email title to AboutCard module.

<img width="1680" alt="Snímek obrazovky 2021-11-12 v 16 43 59" src="https://user-images.githubusercontent.com/79644454/141494676-b5b0718b-1d47-4f36-99e0-ceebc48442ca.png">
