### PR TITLE
auto param assignment, addAlert documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,8 @@
 
 - SidebarItem's name is revealed upon hover (INDIGO Sprint 211112, [!208](https://github.com/TeskaLabs/asab-webui/pull/208))
 
+- Method addAlert() now automaticaly determines whether arg1 and arg2 are the expiration time or shouldBeTranslated boolean. (INDIGO Sprint 211112, [!211](https://github.com/TeskaLabs/asab-webui/pull/211))
+
 ### Bugfixes
 
 - Update auth header dropdown and `Access control screen` to prevent app from crashing when tenant module is not enabled (INDIGO Sprint 210430, [!105](https://github.com/TeskaLabs/asab-webui/pull/105))

--- a/doc/addAlert.md
+++ b/doc/addAlert.md
@@ -1,0 +1,23 @@
+# addAlert method intro
+
+- addAlert(level, message, arg1, arg2) is a method of Application.js
+- takes 4 arguments
+    - level (string) 
+        - sets message's styling variant as per bootstrap standard ('success', 'danger', 'warning', 'light', ...)
+
+    - message (string || function (in functional component only)) 
+        - as per i18n standard
+
+    - arg1, arg 2 (one of them is a number, the other is a boolean) 
+        - both otional arguments
+        - stand for expiration time in seconds (default is 5 seconds) and a boolean deciding wheter the message should be translated(especially for class components, default set to false)
+
+# example of use
+
+- in class component 
+    - this.App.addAlert("danger", "ASABAuthModule|You are not authorized to use this application", 3600, true)
+    - this.App.addAlert("danger", "ASABAuthModule|You are not authorized to use this application", true, 3)
+
+- in functional component
+    - props.app.addAlert("warning", t(`ASABConfig|Unable to get types`))
+    - props.app.addAlert("success", t(`ASABConfig|Unable to get types`), 10)

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -417,7 +417,10 @@ class Application extends Component {
 		* success
 	*/
 
-	addAlert(level, message, expire = 5, shouldBeTranslated = false) {
+	addAlert(level, message, arg1, arg2) {
+		const expire = typeof arg1 === 'number' ? arg1 : typeof arg2 === 'number' ? arg2 : 5;
+		const shouldBeTranslated = typeof arg1 === 'boolean' ? arg1 : typeof arg2 === 'boolean' ? arg2 : false;
+
 		this.Store.dispatch({
 			type: ADD_ALERT,
 			level: level,


### PR DESCRIPTION
method addAlert(level, message, arg1, arg2) now automaticaly determines whether arg1 and arg2 are the expiration time or shouldBeTranslated boolean. Also, addAlert.md file has been added.