### PR TITLE
Fix sidebar auto open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,3 +217,5 @@
 - Fix breadcrumbs for dynamic routes or crumbs which doesn't have name (INDIGO Sprint 211029, [!196](https://github.com/TeskaLabs/asab-webui/pull/196))
 
 - Fix sidebar items order for minimized sidebar (INDIGO Sprint 211112, [!210](https://github.com/TeskaLabs/asab-webui/pull/210))
+
+- Fix sidebar auto open (INDIGO Sprint 211126,[!215](https://github.com/TeskaLabs/asab-webui/pull/215))

--- a/src/sidebar/reducer.js
+++ b/src/sidebar/reducer.js
@@ -20,10 +20,7 @@ export default (state = initialState, action) => {
 			}
 		}
 		default: {
-			return {
-				...state,
-				isSidebarOpen: true
-			}
+			return state;
 		}
 
 	}


### PR DESCRIPTION
Accidentally in default in switch of sidebar reducer I was passing initial value. After any other action this default was triggered and was opening sidebar.