### PR TITLE
Fix sidebar auth filter condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,4 +218,6 @@
 
 - Fix sidebar items order for minimized sidebar (INDIGO Sprint 211112, [!210](https://github.com/TeskaLabs/asab-webui/pull/210))
 
-- Fix sidebar auto open (INDIGO Sprint 211126,[!215](https://github.com/TeskaLabs/asab-webui/pull/215))
+- Fix sidebar auto open (INDIGO Sprint 211126, [!215](https://github.com/TeskaLabs/asab-webui/pull/215))
+
+- Fix sidebar items filter condition (INDIGO Sprint 211126, [!216](https://github.com/TeskaLabs/asab-webui/pull/216))

--- a/src/containers/Sidebar/index.js
+++ b/src/containers/Sidebar/index.js
@@ -23,7 +23,7 @@ const Sidebar = (props) => {
 			});
 		}
 
-		if (unauthorizedNavItems != undefined || unauthorizedNavItems.length != 0) {
+		if (unauthorizedNavItems != undefined && unauthorizedNavItems.length != 0) {
 			itemsList = itemsList.filter((item) => unauthorizedNavItems.indexOf(item.name) == -1);
 		}
 
@@ -41,7 +41,7 @@ const Sidebar = (props) => {
 							key={idx}
 							item={item}
 							unauthorizedNavChildren={unauthorizedNavChildren}
-							uncollapseAll={memoizedItemsList.length <= 2}
+							uncollapseAll={memoizedItemsList?.length <= 2}
 						/>
 					))}
 				</Nav>

--- a/src/containers/Sidebar/index.js
+++ b/src/containers/Sidebar/index.js
@@ -41,7 +41,7 @@ const Sidebar = (props) => {
 							key={idx}
 							item={item}
 							unauthorizedNavChildren={unauthorizedNavChildren}
-							uncollapseAll={memoizedItemsList?.length <= 2}
+							uncollapseAll={memoizedItemsList.length <= 2}
 						/>
 					))}
 				</Nav>


### PR DESCRIPTION
Without that fix sidebar was trying to get length from `unauthorizedNavItems` and app was crashing when `unauthorizedNavItems` is `undefined`