### PR TITLE
Refactor/size option as prop in custom switch components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,8 @@
 
 - Make init method of tenant service syncronous and make _extract_tenant_from_url() a private method (INDIGO Sprint 211126, [!217](https://github.com/TeskaLabs/asab-webui/pull/217))
 
+- Custom switch components noc accept size as a property (INDIGO Sprint 211210, [!221](https://github.com/TeskaLabs/asab-webui/pull/221))
+
 ### Bugfixes
 
 - Update auth header dropdown and `Access control screen` to prevent app from crashing when tenant module is not enabled (INDIGO Sprint 210430, [!105](https://github.com/TeskaLabs/asab-webui/pull/105))

--- a/doc/switch-components.md
+++ b/doc/switch-components.md
@@ -7,6 +7,7 @@
     - toggle (function) - triggered upon click
     - title (string / optional)
     - disabled (boolean / optional)
+    - size ('sm', 'md', 'lg' / optional / default is 'md') - defines switchers size just as one would'd expect in reactstrap
 
 - example:
 ```
@@ -16,7 +17,7 @@
     const YourComponent = (props) => {
 	    const [isOn, setIsOn] = useState(false)
 		return (
-			<ControlledSwitch  toggle={() => setIsOn(!isOn)} title='setTotp' isOn={isOn}/>
+			<ControlledSwitch  toggle={() => setIsOn(!isOn)} title='setTotp' isOn={isOn} size='lg'/>
 		)
     } 
 ```

--- a/src/containers/ControlledSwitch/index.js
+++ b/src/containers/ControlledSwitch/index.js
@@ -4,13 +4,13 @@ import './switch.scss';
 
 // documentation available in asab-webui/doc/switch-components.md
 
-const Switch = ({ isOn, toggle, disabled=false, title }) => {
+const Switch = ({ isOn, toggle, disabled=false, title, size='md' }) => {
 	const onClick = () => {
 		if (!disabled) toggle();
 	}
 	
 	return (
-		<div className={`switch-container${disabled ? "-disabled" : ""}`} title={title}>
+		<div className={`switch-container${disabled ? "-disabled" : ""} ${size}`} title={title}>
 			<div className={isOn ? "on" : "off"} onClick={onClick}>
 				<div className="circle"></div>
 			</div>

--- a/src/containers/ControlledSwitch/switch.scss
+++ b/src/containers/ControlledSwitch/switch.scss
@@ -6,7 +6,23 @@
 	border: 1px solid #6c757d;
 	display: inline-block;
 	border-radius: 50px;
+	margin-bottom: -2.5px;
 	cursor: pointer;
+
+	&.lg {
+		width: 52px;
+		height: 26px;
+		.on .circle {
+				margin-left: 25px;
+			}
+	}
+	&.sm {
+		width: 32px;
+		height: 16px;
+		.on .circle {
+			margin-left: 15px;
+		}
+	}
 
 	* {
 		border-radius: 50px;
@@ -17,7 +33,7 @@
 	.on, .off {
 		position: relative;
 		width: 100%;
-		display: inline-block;
+		// display: inline-block;
 
 		.circle {
 			width: 50%;

--- a/src/containers/UncontrolledSwitch/index.js
+++ b/src/containers/UncontrolledSwitch/index.js
@@ -5,7 +5,8 @@ import { ControlledSwitch } from 'asab-webui';
 
 const UncontrolledSwitch = ({ 
 	defaultValue = false, disabled = false, 
-	title, register, setValue, name = 'uncontrolled switch', id
+	title, register, setValue, name = 'uncontrolled switch', id, 
+	size = 'md'
 }) => {
 		const [isOn, setIsOn] = useState(defaultValue);
 
@@ -20,6 +21,7 @@ const UncontrolledSwitch = ({
 					title={title}
 					disabled={disabled}
 					toggle={() => setIsOn(prev => !prev)}
+					size={size}
 				/>
 				<input
 					type="checkbox"


### PR DESCRIPTION
ControlledSwitch and UncotrolledSwitch components now accept size props 

```
<UncontrolledSwitch size='lg' register={register} setValue={setValue} name='value' />
...
<ControlledSwitch size='md' toggle={()=>setIsOn(!isOn)} title='switcher'  isOn={isOn}/>	

```


https://user-images.githubusercontent.com/79644454/148102135-6be17728-22c4-4f75-b1aa-472bdfcbaf5c.mov

