### PR TITLE
Fix failed response issue on list of configs under one one node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,3 +237,5 @@
 - Fix sidebar auto open (INDIGO Sprint 211126, [!215](https://github.com/TeskaLabs/asab-webui/pull/215))
 
 - Fix sidebar items filter condition (INDIGO Sprint 211126, [!216](https://github.com/TeskaLabs/asab-webui/pull/216))
+
+- Fix issue on failed response for ASAB-Config's module TreeMenu. It broke the application when there was some issue (wrong file type) e.g. in schema or config file (INDIGO Sprint 211126, [!216](https://github.com/TeskaLabs/asab-webui/pull/226))

--- a/src/modules/asab-config/ConfigContainers/TreeViewComponent.js
+++ b/src/modules/asab-config/ConfigContainers/TreeViewComponent.js
@@ -54,8 +54,9 @@ export function TreeViewComponent(props) {
 		let tree = {};
 		try {
 			let response = await ASABConfigAPI.get("/config/" + typeId);
-			// TODO: validate responses which are not 200
-			tree[typeId] = response.data
+			if (response.data.result !== 'FAIL'){
+				tree[typeId] = response.data
+			}
 			return tree;
 		}
 		catch {


### PR DESCRIPTION
- Fix issue on failed response for TreeMenu (it broke the application when there was some issue in schema or config file, e.g. wrong file type or some typo)