### PR TITLE
Automatic closing of the sidebar on sidebar item click for small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@
 
 - Add possibility to configure items count limit in MicroservicesContainer (INDIGO Sprint 220107, [!223](https://github.com/TeskaLabs/asab-webui/pull/223))
 
+- Automatic closing of the sidebar on sidebar items click for small screens (INDIGO Sprint 220121, [!228](https://github.com/TeskaLabs/asab-webui/pull/228))
+
 ### Refactoring
 
 - Renaming configuration option FAKE_USERINFO to MOCK_USERINFO and refactoring code accordingly (INDIGO Sprint 210406, [!91](https://github.com/TeskaLabs/asab-webui/pull/91))

--- a/src/containers/Main.js
+++ b/src/containers/Main.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 
 const Main = ({
@@ -7,9 +7,20 @@ const Main = ({
 }) => {
 	const withSidebar = hasSidebar !== false && isSidebarOpen ? "-with-sidebar" : "",
 		isMinimized = isSidebarOpen && isSidebarMinimized ? "-minimized" : "";
+	const [width, setWidth] = useState(window.innerWidth);
+
+	useEffect(() => {
+		window.addEventListener("resize", onWidthChange);
+
+		return (() => {
+			window.removeEventListener("resize", onWidthChange);
+		})
+	}, [width]);
+
+	const onWidthChange = () => setWidth(window.innerWidth);
 
 	const stopPropagation = e => {
-		if (window.innerWidth < 768 && isSmallSidebarOpen) {
+		if (width < 768 && isSmallSidebarOpen) {
 			console.log("stoped");
 			e.preventDefault();
 			e.stopPropagation();
@@ -19,7 +30,7 @@ const Main = ({
 	return (
 		<main className={`main${withSidebar}${isMinimized}`}>
 			{children}
-			{window.innerWidth < 768 && isSmallSidebarOpen && (
+			{width < 768 && isSmallSidebarOpen && (
 				<div
 					onClick={stopPropagation}
 					className="stop-propagation-container"

--- a/src/containers/Sidebar/SidebarItem.js
+++ b/src/containers/Sidebar/SidebarItem.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useHistory } from 'react-router';
 import { useTranslation } from 'react-i18next';
+import { useSelector, useDispatch } from 'react-redux';
 
 import {
 	Nav, NavItem, NavLink, Collapse
@@ -8,11 +9,17 @@ import {
 
 import Icon from './SidebarIcon';
 
-const SidebarItem = ({ item, unauthorizedNavChildren, uncollapseAll }) => {
+import { SET_SMALL_SIDEBAR } from '../../actions';
+
+const SidebarItem = ({ 
+	item, unauthorizedNavChildren, uncollapseAll
+}) => {
 	const [isOpen, setOpen] = useState(false);
+	const isSmallSidebarOpen = useSelector(state => state.sidebar.isSmallSidebarOpen);
 
 	const location = useLocation();
 	const history = useHistory();
+	const dispatch = useDispatch();
 
 	const { t } = useTranslation();
 
@@ -41,6 +48,8 @@ const SidebarItem = ({ item, unauthorizedNavChildren, uncollapseAll }) => {
 		// Preserve from collapsing when item doesn't have children
 		// or if item should always be uncollapsed
 		else if (item.children && !uncollapseAll) setOpen(prev => !prev);
+		// Close small sidebar on item click
+		if (isSmallSidebarOpen && window.innerWidth < 768) dispatch({ type: SET_SMALL_SIDEBAR });
 	}
 
 	return (

--- a/src/style.scss
+++ b/src/style.scss
@@ -52,6 +52,7 @@ html {
 		top: 55px;
 		background-color: rgba(0,0,0,0.5);
 		overflow-y: hidden;
+		z-index: 999;
 	}
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -40,19 +40,18 @@ html {
 	min-width: 0;
 }
 
-.stop-propagation-container {
-	height: calc(100% + 50px);
-	width: 100%;
-	position: absolute;
-	top: 55px;
-	background-color: rgba(0,0,0,0.5);
-	overflow-y: hidden;
-	
-}
-
 @media screen and (max-width: 768px) {
 	.main, .main-with-sidebar, .main-with-sidebar-minimized {
 		margin-left: 0px !important;
+	}
+
+	.stop-propagation-container {
+		height: calc(100% + 50px);
+		width: 100%;
+		position: absolute;
+		top: 55px;
+		background-color: rgba(0,0,0,0.5);
+		overflow-y: hidden;
 	}
 }
 


### PR DESCRIPTION
Other changes:
- Fix bug when stop-propagation-container wasn't removed on big screens
- Fix bug when some elements (like ace-editor in LibraryContainer) had higher z-index then stop-propagation-container