### PR TITLE
Replace AceEditor with Monaco Editor in Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,8 @@
 
 - Refactor Microservices API calls (INDIGO Sprint 220218, [!241](https://github.com/TeskaLabs/asab-webui/pull/241))
 
+- Replace AceEditor with Monaco Editor in Library  (INDIGO Sprint 220218, [!244](https://github.com/TeskaLabs/asab-webui/pull/244))
+
 ### Bugfixes
 
 - Update auth header dropdown and `Access control screen` to prevent app from crashing when tenant module is not enabled (INDIGO Sprint 210430, [!105](https://github.com/TeskaLabs/asab-webui/pull/105))

--- a/demo/package.json
+++ b/demo/package.json
@@ -45,6 +45,7 @@
 	"dependencies": {
 		"@coreui/coreui": "2.1.4",
 		"@coreui/icons": "^1.0.1",
+		"@monaco-editor/react": "^4.3.1",
 		"axios": "^0.21.1",
 		"date-fns": "^2.28.0",
 		"bootstrap": "4.6.0",

--- a/src/modules/library/containers/LibraryContainer.js
+++ b/src/modules/library/containers/LibraryContainer.js
@@ -17,10 +17,6 @@ import TreeMenuItem from "./TreeMenuItem";
 import { formatIntoTree } from "./formatIntoTree";
 
 import './styles.scss';
-import "ace-builds/src-noconflict/mode-yaml";
-import 'ace-builds/src-noconflict/theme-textmate'; //light with blue
-// TODO: use the below for the dark theme:
-// import 'ace-builds/src-noconflict/theme-idle_fingers'; //dark with yellow
 
 const languages = {
 	'.html': 'html',

--- a/src/modules/library/containers/LibraryContainer.js
+++ b/src/modules/library/containers/LibraryContainer.js
@@ -296,19 +296,6 @@ function LibraryContainer(props) {
 							</div>
 						</CardHeader>
 						<CardBody className="card-body-editor">
-							{/* <AceEditor
-								className="editor"
-								mode="yaml"
-								theme="textmate"
-								value={fileContent}
-								editorProps={{ $blockScrolling: true }}
-								fontSize="1.2rem"
-								readOnly={isReadOnly}
-								width="800"
-								height="100%"
-								showPrintMargin={false}
-								onChange={editFileContent}
-							/> */}
 							<Editor
 								height="100%"
 								width="100%"

--- a/src/modules/library/containers/LibraryContainer.js
+++ b/src/modules/library/containers/LibraryContainer.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { connect } from 'react-redux';
 import { useHistory, useLocation } from "react-router-dom";
+import { useTranslation } from 'react-i18next';
 
 import {
 	Container, ListGroup, Input,
@@ -9,8 +10,7 @@ import {
 	ButtonGroup
 } from "reactstrap";
 import TreeMenu from 'react-simple-tree-menu';
-import { useTranslation } from 'react-i18next';
-import AceEditor from "react-ace";
+import Editor from '@monaco-editor/react';
 import { ControlledSwitch } from 'asab-webui';
 
 import TreeMenuItem from "./TreeMenuItem";
@@ -21,6 +21,18 @@ import "ace-builds/src-noconflict/mode-yaml";
 import 'ace-builds/src-noconflict/theme-textmate'; //light with blue
 // TODO: use the below for the dark theme:
 // import 'ace-builds/src-noconflict/theme-idle_fingers'; //dark with yellow
+
+const languages = {
+	'.html': 'html',
+	'.xml': 'xml',
+	'.js': 'javascript',
+	'.py': 'python',
+	'.yaml': 'yaml',
+	'.yml': 'yaml',
+	'.json': 'json',
+	'.css': 'css',
+	'.scss': 'scss'
+}
 
 function LibraryContainer(props) {
 
@@ -37,6 +49,7 @@ function LibraryContainer(props) {
 	const [activeNode, setActiveNode] = useState({ });
 	const [isFileDisabled, setFileDisabled] = useState("disable-switch");
 	const [isReadOnly, setReadOnly] = useState(true);
+	const [language, setLanguage] = useState('');
 	const isComponentMounted = useRef(true);
 
 	useEffect(() => {
@@ -59,6 +72,7 @@ function LibraryContainer(props) {
 		// copy originalFileContent for edditing
 		// copy is required in order to discard changes
 		setFileContent(originalFileContent);
+		setFileLanguage(activeNode.name);
 	}, [originalFileContent])
 
 	useEffect(() => {
@@ -169,7 +183,14 @@ function LibraryContainer(props) {
 		}
 	}
 
-	const editFileContent = value => setFileContent(value);
+	const setFileLanguage = value => {
+		const extension = value?.match(/\.[0-9a-z]+$/i)[0];
+		setLanguage(languages[extension] || "");
+	}
+
+	const editFileContent = value => {
+		setFileContent(value);
+	}
 
 	const cancelChanges = () => {
 		const confirmation = confirm(t("ASABLibraryModule|Are you sure you want to cancel changes?"));
@@ -279,7 +300,7 @@ function LibraryContainer(props) {
 							</div>
 						</CardHeader>
 						<CardBody className="card-body-editor">
-							<AceEditor
+							{/* <AceEditor
 								className="editor"
 								mode="yaml"
 								theme="textmate"
@@ -291,6 +312,16 @@ function LibraryContainer(props) {
 								height="100%"
 								showPrintMargin={false}
 								onChange={editFileContent}
+							/> */}
+							<Editor
+								height="100%"
+								width="100%"
+								className="editor"
+								value={fileContent}
+								defaultValue=""
+								language={language}
+								onChange={editFileContent}
+								options={{ readOnly: isReadOnly }}
 							/>
 						</CardBody>
 					</Card>


### PR DESCRIPTION
**CHANGES**:
- AceEditor was replaced with Monaco Editor in Library
- Added support for different languages (yaml, json, xml, html, javascript, python, css, scss). Library identify language base on active node name.
- Size of the packages was reduced - in lmio-webui now stat size of node-modules is 4.4MB (was 5MB), parsed size is 1.79MB (was 2MB) and gziped size is 500KB (was 620KB)

**OTHER CHANGES**:
- AceEditor was replaced with Monaco Editor in Export Declaration screen (http://gitlab.teskalabs.int/bitswan/bitswan-webui/-/merge_requests/91)
- AceEditor was replaced with Monaco Editor in SPLang WebUI (http://gitlab.teskalabs.int/lmio/sp-lang-webui/-/merge_requests/4)

**IMPORTANT NOTE**: Monaco Editor doesn't support mobile browsers - this means that for someone it may work as editor, for others it will be used only in read-only mode and/or some features may not work