### PR TITLE
DataTable - refactor content loader conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,8 @@
 
 - Obsolete console.log removal (INDIGO Sprint 220304, [!251](https://github.com/TeskaLabs/asab-webui/pull/251))
 
+- DataTable accepts showContentLoader prop to add the possibility to postpone loaders appearance in order to avoid quick flickering of data/contentloader/new data (INDIGO Sprint 220304, [!252](https://github.com/TeskaLabs/asab-webui/pull/252))
+
 ### Bugfixes
 
 - Update auth header dropdown and `Access control screen` to prevent app from crashing when tenant module is not enabled (INDIGO Sprint 210430, [!105](https://github.com/TeskaLabs/asab-webui/pull/105))

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -30,7 +30,8 @@ export function DataTable ({
 	customButton, customComponent,
 	customRowStyle, customRowClassName,
 	customCardBodyComponent,
-	limitValues = [10, 15, 25, 50]
+	limitValues = [10, 15, 25, 50],
+	showContentLoader = true
 	}) {
 	const [filterValue, setFilterValue] = useState('');
 	const [isSortOpen, setSortDropdown] = useState(false);
@@ -163,15 +164,15 @@ export function DataTable ({
 
 					<CardBody className="data-table-card-body">
 						{customCardBodyComponent}
-						{isLoading ? 
-							<CellContentLoader cols={headers.length} rows={limit ?? 5} /> :
-							<Table
-								data={data.length > limit ? data.slice(0, limit) : data}
-								headers={headers}
-								rowStyle={customRowStyle}
-								rowClassName={customRowClassName}
-							/>
-						}
+						<Table
+							data={data.length > limit ? data.slice(0, limit) : data}
+							headers={headers}
+							rowStyle={customRowStyle}
+							rowClassName={customRowClassName}
+						/>
+
+						{isLoading && showContentLoader && <CellContentLoader cols={headers.length} rows={limit ?? 5} /> }
+
 						{count === 0 && !isLoading && (
 							noItemsComponent ? <NoItemsLayout>{noItemsComponent}</NoItemsLayout> :
 							<NoItemsLayout>{t(translationRoute ? `${translationRoute}|No items` : "No items")}</NoItemsLayout>

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -31,7 +31,7 @@ export function DataTable ({
 	customRowStyle, customRowClassName,
 	customCardBodyComponent,
 	limitValues = [10, 15, 25, 50],
-	showContentLoader = true
+	contentLoader = true
 	}) {
 	const [filterValue, setFilterValue] = useState('');
 	const [isSortOpen, setSortDropdown] = useState(false);
@@ -171,7 +171,7 @@ export function DataTable ({
 							rowClassName={customRowClassName}
 						/>
 
-						{isLoading && showContentLoader && <CellContentLoader cols={headers.length} rows={limit ?? 5} /> }
+						{isLoading && contentLoader && <CellContentLoader cols={headers.length} rows={limit ?? 5} /> }
 
 						{count === 0 && !isLoading && (
 							noItemsComponent ? <NoItemsLayout>{noItemsComponent}</NoItemsLayout> :


### PR DESCRIPTION
`DataTable` now takes `showContentLoader` prop to add the possibility to postpone loaders appearance 
- this was implemented to avoid quick flickering of data/contentloader/new data when changing paginating with good connection


#### before ( no throttling

https://user-images.githubusercontent.com/79644454/158960220-8ee6def2-dc81-4999-8f11-26ea766327b2.mov

#### after (throttled to slow 3G)

https://user-images.githubusercontent.com/79644454/158960247-01d0169b-b5c7-4190-82cf-44b554dc0c1b.mov

#### after (no throttling)

https://user-images.githubusercontent.com/79644454/158961574-7f6fc2e2-cd5c-44bf-a698-4aba2f418e75.mov

