### PR TITLE
Possibility to pass a function to generate subpath in DataTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@
 
 - Add option to remove section from config in ASAB-Config module (INDIGO Sprint 220304, [!248](https://github.com/TeskaLabs/asab-webui/pull/248))
 
+- Add an option to construct a link in DataTable's cell using a function (INDIGO Sprint 220318, [!255](https://github.com/TeskaLabs/asab-webui/pull/255))
+
 
 ### Refactoring
 

--- a/doc/datatable/datatable.md
+++ b/doc/datatable/datatable.md
@@ -99,12 +99,26 @@ Prop `headers` is basically an array containing objects with obligatory properti
 
 Property `name` is a string that will be rendered as a header cell in headers row of the table. Property `key` is a key name for getting data from `data` prop, it must be the same as it is in objects in `data` prop.
 
-Optional property `link` is an object containing properties `pathname` and `key`. `pathname` is a string which is representing pathname for <Link> component, `key` is a key name for getting id for pathname. 
+Optional property `link` is either an object or a function. 
+Object contains properties `pathname` and `key`, where `pathname` is a string which is representing pathname for <Link> component and `key` is a key name for getting id for pathname.
 Output for link cell would look like:
 
 ```
 <Link to={{ pathname: link.pathname + obj[link.key] }} >
 ```
+A function allows more variability and returns complete path. Output for link cell would be a string returned from calling the link function.
+
+```
+const headers = [
+		...,
+		{
+			name: 'Demo Link',
+			key: 'username',
+			link: (obj, header) => `my/awesome/custom/path/${header.key}/${obj.username}`,
+		}
+	];
+```
+
 
 If `pathname` is "/user/", `key` is "_id" and data for that cell is 
 {

--- a/doc/datatable/datatable.md
+++ b/doc/datatable/datatable.md
@@ -577,7 +577,7 @@ props: {
   headers: Array<{
     name: string, // name of the headers in a table
     key: 'string'', // name of the key for searching properties in objects in props.data
-	link?: {
+	link?: function | {
 		pathname: string,
 		key: string
 	},

--- a/src/components/DataTable/Table.js
+++ b/src/components/DataTable/Table.js
@@ -53,7 +53,12 @@ const TableCell = ({ obj, header, idx, showJson, jsonTheme }) => {
 	);
 
 	else if (header.link) {
-		const pathname = header.link.pathname + obj[header.link.key];
+		let pathname = "#";
+		if (typeof header.link === "object") {
+			pathname = header.link.pathname + obj[header.link.key];
+		} else if (typeof header.link === "function") {
+			pathname = header.link(obj, header);
+		}
 		cell = obj[header.key] ? (
 			<Link
 				to={{ pathname }}


### PR DESCRIPTION
Currently we generate links for this type of cells from objects : `link: { pathname: "my/pathname/", key: "_id" }`

And the result is  pathname + key  (e.g. `my/pathname/123` where `123` is `_id` )

This feature introduces another option to construct these paths with a function.n This will give us more freedom in future for generating those links and keep regular styles for those links without need to use customComponent


https://user-images.githubusercontent.com/79644454/160885443-bcecf358-863b-44cf-b704-1aafebcf556a.mp4


