### PR TITLE
Move API call initialization from constructor of service to init part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,3 +309,5 @@
 - Add monaco loader plugin to webpack.build.js (INDIGO Sprint 220401, [!260](https://github.com/TeskaLabs/asab-webui/pull/260))
 
 - Fix library global styles (INDIGO Sprint 220401, [!262](https://github.com/TeskaLabs/asab-webui/pull/262))
+
+- Fix missing authorization bearer token in the header of Sidebar request on ASAB-Config service (INDIGO Sprint 220419, [!265](https://github.com/TeskaLabs/asab-webui/pull/265))

--- a/src/containers/Sidebar/service.js
+++ b/src/containers/Sidebar/service.js
@@ -10,7 +10,6 @@ export default class SidebarService extends Service {
 
 	constructor(app, serviceName="SidebarService"){
 		super(app, serviceName);
-		this.ASABConfigAPI = this.App.axiosCreate('asab_config');
 	}
 
 
@@ -26,7 +25,8 @@ export default class SidebarService extends Service {
 	async getSidebarHiddenItems(configName) {
 		let hiddenItems = undefined;
 		try {
-			let response = await this.ASABConfigAPI.get(`/config/Sidebar/${configName}?format=json`);
+			const ASABConfigAPI = this.App.axiosCreate('asab_config');
+			let response = await ASABConfigAPI.get(`/config/Sidebar/${configName}?format=json`);
 			if (response.data.result != "OK") {
 				throw new Error("Config file to get data for Sidebar can't be found in Zookeeper")
 			}


### PR DESCRIPTION
- This is a bugfix, the initialization of Service API in the constructor part of the service was causing the not appending Authroization Header in the request. This initialization has been moved to init part of the service to prevent previously described issue.