### PR TITLE
Bugfix/pagination issue upon last item removal in datatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,3 +323,5 @@
 - Fix missing authorization bearer token in the header of Sidebar request on ASAB-Config service (INDIGO Sprint 220419, [!265](https://github.com/TeskaLabs/asab-webui/pull/265))
 
 - Fix global vars (INDIGO Sprint 220429, [!272](https://github.com/TeskaLabs/asab-webui/pull/272))
+
+- Fix pagination' diappearance issue upon last item removal in DataTable (INDIGO Sprint 220429, [!274](https://github.com/TeskaLabs/asab-webui/pull/274))

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -195,12 +195,12 @@ export function DataTable ({
 							) : null
 						}
 
-						{count > limit && setPage &&
+						{setPage &&
 							<Col>
 								<Pagination 
-								currentPage={currentPage}
-								setPage={setPage}
-								lastPage={Math.ceil(count/limit)}
+									currentPage={currentPage}
+									setPage={setPage}
+									lastPage={Math.ceil(count/limit)}
 								/>
 							</Col>
 						}

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
 
@@ -22,6 +22,12 @@ export default function ({ currentPage, setPage, lastPage }) {
 	for (let i = start; i <= end; i++) {
 		pages.push(i);
 	}
+
+	useEffect(() => {
+		if (currentPage > lastPage && lastPage != 0) {
+			setPage(lastPage);
+		}
+	}, [lastPage])
 
 	return (
 		<Pagination>


### PR DESCRIPTION
Fixes issue with disappearance of pagination when last item on a page has been removed from within DataTable. 

(limit set to 2 just for demo purposes)

https://user-images.githubusercontent.com/79644454/167090401-15673497-9071-45df-9fbd-1218d9038a19.mov

