### PR TITLE
Bugfix/card footer pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,3 +343,5 @@
 - Fix global vars (INDIGO Sprint 220429, [!272](https://github.com/TeskaLabs/asab-webui/pull/272))
 
 - Fix pagination' diappearance issue upon last item removal in DataTable (INDIGO Sprint 220429, [!274](https://github.com/TeskaLabs/asab-webui/pull/274))
+
+- Fix pagination's position after decomposing of DataTable, vertical allignment in DataTable's card footer and disappearance of pagination when no data is preset (INDIGO Sprint 220527, [!285](https://github.com/TeskaLabs/asab-webui/pull/285))

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -134,41 +134,41 @@ export function DataTable ({
 
 					<CardFooter className="data-table-card-footer">
 						<Row>
-						{count ? (
 							<Col sm="4">
-								<div>
-									{t(translationRoute ? 
-										`${translationRoute}|Showing item(s)` 
-										: "Showing item(s)",
-										{ length: data.length, count: count }
-									)}
-								</div>
+								{count ? (
+									<div>
+										{t(translationRoute ? 
+											`${translationRoute}|Showing item(s)` 
+											: "Showing item(s)",
+											{ length: data.length, count: count }
+										)}
+									</div>
+									) : null
+								}
 							</Col>
-							) : null
-						}
 
-						{setPage &&
 							<Col>
-								<Pagination 
-									currentPage={currentPage}
-									setPage={setPage}
-									lastPage={Math.ceil(count/limit)}
-									style={{marginBottom: "0"}}
-								/>
+								{setPage && data.length > 0 &&
+									<Pagination 
+										currentPage={currentPage}
+										setPage={setPage}
+										lastPage={Math.ceil(count/limit)}
+										style={{marginBottom: "0", justifyContent: "center"}}
+									/>
+								}
 							</Col>
-						}
 
-						{setLimit &&
 							<Col>
-								<LimitDropdown 
-									translationRoute={translationRoute}
-									limit={limit}
-									setLimit={setLimit}
-									setPage={setPage}
-									limitValues={limitValues}
-								/>
+								{setLimit &&
+									<LimitDropdown 
+										translationRoute={translationRoute}
+										limit={limit}
+										setLimit={setLimit}
+										setPage={setPage}
+										limitValues={limitValues}
+									/>
+								}
 							</Col>
-						}
 						</Row>
 					</CardFooter>
 				</Card>

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -153,6 +153,7 @@ export function DataTable ({
 									currentPage={currentPage}
 									setPage={setPage}
 									lastPage={Math.ceil(count/limit)}
+									style={{marginBottom: "0"}}
 								/>
 							</Col>
 						}

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 
 import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
 
-export default function ({ currentPage, setPage, lastPage }) {
+export default function ({ currentPage, setPage, lastPage, style }) {
 	const slots = Math.min(5, lastPage);
 
 	let start = currentPage - Math.floor(slots / 2);
@@ -30,7 +30,7 @@ export default function ({ currentPage, setPage, lastPage }) {
 	}, [lastPage])
 
 	return (
-		<Pagination>
+		<Pagination style={style}>
 			<PaginationItem disabled={currentPage == 1}>
 				<PaginationLink
 					onClick={() => setPage(1)}

--- a/src/style.scss
+++ b/src/style.scss
@@ -547,10 +547,10 @@ main > .container-fluid, main > .container {
 .data-table-card .card-footer .row {
 	align-items: center;
 }
-// // Import styles
-// @import "~@coreui/coreui/scss/coreui.scss";
-// // Temp fix for reactstrap
-// @import '~@coreui/coreui/scss/_dropdown-menu-right.scss';
+// Import styles
+@import "~@coreui/coreui/scss/coreui.scss";
+// Temp fix for reactstrap
+@import '~@coreui/coreui/scss/_dropdown-menu-right.scss';
 // Import default bootstrap styles
 @import '~bootstrap/dist/css/bootstrap.min.css';
 // CoreUI Icons Set

--- a/src/style.scss
+++ b/src/style.scss
@@ -543,10 +543,14 @@ main > .container-fluid, main > .container {
 	background-color: #fff;
 }
 
-// Import styles
-@import "~@coreui/coreui/scss/coreui.scss";
-// Temp fix for reactstrap
-@import '~@coreui/coreui/scss/_dropdown-menu-right.scss';
+//DataTable's card footer items position
+.data-table-card .card-footer .row {
+	align-items: center;
+}
+// // Import styles
+// @import "~@coreui/coreui/scss/coreui.scss";
+// // Temp fix for reactstrap
+// @import '~@coreui/coreui/scss/_dropdown-menu-right.scss';
 // Import default bootstrap styles
 @import '~bootstrap/dist/css/bootstrap.min.css';
 // CoreUI Icons Set


### PR DESCRIPTION
fixed DataTable's position of pagination, vertical alignment of items, paginations margin bottom which created uneven cardfooter's size and pagination's disappearance when no data is present

@Pe5h4 


<img width="1144" alt="Snímek obrazovky 2022-06-03 v 14 11 13" src="https://user-images.githubusercontent.com/79644454/171852312-43c7a290-0f3b-4afc-b018-3a4587d252af.png">
<img width="1198" alt="Snímek obrazovky 2022-06-03 v 14 15 53" src="https://user-images.githubusercontent.com/79644454/171852317-56205f50-936b-4948-8789-dc1c9195797e.png">
<img width="1038" alt="Snímek obrazovky 2022-06-03 v 14 18 31" src="https://user-images.githubusercontent.com/79644454/171852322-c2f94278-64ad-491f-860d-b8a8b635738a.png">
