### PR TITLE
Refactor/new design/data table count

### DIFF
--- a/demo/public/locales/cs/translation.json
+++ b/demo/public/locales/cs/translation.json
@@ -131,6 +131,6 @@
 		"Version": "Verze",
 		"Attention": "Pozor"
 	},
-
+	"Showing item(s)": "{{ from }} - {{ to }} z {{ total }} položek",
 	"You do not have access rights to perform this action": "Váš přístup je omezen, nemáte dostatečná oprávnění"
 }

--- a/demo/public/locales/en/translation.json
+++ b/demo/public/locales/en/translation.json
@@ -131,6 +131,6 @@
 		"Version": "Version",
 		"Attention": "Attention"
 	},
-
+	"Showing item(s)": "{{ from }} - {{ to }} of {{ total }} item(s)",
 	"You do not have access rights to perform this action": "You do not have access rights to perform this action"
 }

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -52,16 +52,6 @@ export function DataTable ({
 		}, 500);
 	}, [filterValue]);
 
-	useEffect(() => {
-		if((data.length - (currentPage*limit) + 1) < 1) {
-			setCountDigit(1)
-		} else if (limit < data.length && currentPage === 1 ){
-			setCountDigit(1)
-		} else {
-			setCountDigit(data.length - (currentPage*limit) + 1)
-		}
-	}, [limit])
-
 	return (
 		<Row className="h-100">
 			<Col>
@@ -140,7 +130,7 @@ export function DataTable ({
 									{t(translationRoute ? 
 										`${translationRoute}|Showing item(s)` 
 										: "Showing item(s)",
-										{ length: data.length, count: count }
+										{ count: count, first: (currentPage - 1) * limit + 1, max: count > currentPage * limit ? data.length : count}
 									)}
 								</div>
 								) : null

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -130,7 +130,7 @@ export function DataTable ({
 									{t(translationRoute ? 
 										`${translationRoute}|Showing item(s)` 
 										: "Showing item(s)",
-										{ count: count, first: (currentPage - 1) * limit + 1, max: count > currentPage * limit ? data.length : count}
+										{ from: (currentPage - 1) * limit + 1, to: count > currentPage * limit ? data.length : count, total: count }
 									)}
 								</div>
 								) : null

--- a/src/styles/components/card.scss
+++ b/src/styles/components/card.scss
@@ -45,6 +45,9 @@ $box-shadow-card-color: var(--box-shadow-card-color);
 			h3 {
 				margin: auto;
 			}
+			.card-subtitle {
+				padding: 0 0.5rem;
+			}
 		}
 		.btn-group {
 			padding: 0;


### PR DESCRIPTION
changes: 
- adds padding to cardheader's subtitle 
- count in DataTable's footer as per new design.

locales updates needed 
```
en/translation.json
"Showing item(s)": "{{ from }} - {{ to }} of {{ total }} item(s)",

cs/translation.json
"Showing item(s)": "{{ from }} - {{ to }} z {{ total }} položek",
```