### PR TITLE
Refactor/new design/advanced mode styling

### DIFF
--- a/src/components/DataTable/Table.js
+++ b/src/components/DataTable/Table.js
@@ -149,6 +149,7 @@ const TableRow = ({
 }) => {
 	const [isAdvUnwrapped, setAdvUnwrapped] = useState(false);
 	const [isSubUnwrapped, setSubUwrapped] = useState(true);
+	const theme = useSelector(state => state?.theme);
 
 	const getStyle = (obj) => {
 		if (rowStyle?.condition && rowStyle?.condition(obj)) {
@@ -170,6 +171,9 @@ const TableRow = ({
 		}
 		else if (rowClassName?.jsonTheme && rowClassName?.condition(obj)) {
 			return rowClassName.jsonTheme;
+		}
+		else if (theme !== "light") {
+			return "brewer";
 		} 
 		else {
 			return "rjv-default";
@@ -178,7 +182,7 @@ const TableRow = ({
 
 	const style = useMemo(() => getStyle(obj), [obj]);
 	const className = useMemo(() => getClassName(obj), [obj]);
-	const jsonTheme = useMemo(() => getJsonTheme(obj), [obj]);
+	const jsonTheme = useMemo(() => getJsonTheme(obj, theme), [obj, theme]);
 
 	return (
 		<>
@@ -237,6 +241,7 @@ const TableRow = ({
 						<ReactJson
 							src={obj}
 							name={false}
+							theme={theme === "light" ? "rjv-default" : "brewer"}
 						/>
 					</td>
 				</tr>


### PR DESCRIPTION
Changes json theme based on color both in regular json table cell and in advanced mode  

<img width="840" alt="Snímek obrazovky 2022-07-06 v 19 13 45" src="https://user-images.githubusercontent.com/79644454/177606688-3c3d7ae5-29b4-418c-9977-2c31952b595d.png">
