### PR TITLE
Refactor/new design/datatable wrapping fix

### DIFF
--- a/src/components/DataTable/Table.js
+++ b/src/components/DataTable/Table.js
@@ -112,7 +112,8 @@ const TableCell = ({
 				{cell}
 			</th>
 		) : (
-			<td className="pl-3 data-table-td" style={{ whiteSpace: "nowrap", ...customStyle }}>
+			<td className="pl-3 data-table-td" style={{ ...customStyle }}>
+			{/* <td className="pl-3 data-table-td" style={{ whiteSpace: "nowrap", ...customStyle }}> */}
 				{cell}
 			</td>
 		);
@@ -126,7 +127,8 @@ const Headers = ({ headers, advmode, sublists }) => (
 			{headers.map((_, idx) =>
 				<col
 					className={`data-table-col${idx}`}
-					style={{ width: (idx === headers.length - 1) ? "auto" : "1px" }}
+					// style={{ width: (idx === headers.length - 1) ? "auto" : "1px" }}
+					style={{ width: "auto"}}
 					key={idx}
 				/>
 			)}

--- a/src/components/DataTable/Table.js
+++ b/src/components/DataTable/Table.js
@@ -113,7 +113,6 @@ const TableCell = ({
 			</th>
 		) : (
 			<td className="pl-3 data-table-td" style={{ ...customStyle }}>
-			{/* <td className="pl-3 data-table-td" style={{ whiteSpace: "nowrap", ...customStyle }}> */}
 				{cell}
 			</td>
 		);
@@ -127,14 +126,12 @@ const Headers = ({ headers, advmode, sublists }) => (
 			{headers.map((_, idx) =>
 				<col
 					className={`data-table-col${idx}`}
-					// style={{ width: (idx === headers.length - 1) ? "auto" : "1px" }}
 					style={{ width: "auto"}}
 					key={idx}
 				/>
 			)}
 		</colgroup>
 
-		{/* <thead className={`thead-${theme === "theme-dark" || !theme ? "light" : "dark"} data-table-thead`}> */}
 		<thead className="data-table-thead">
 			<tr className="data-table-tr">
 				{advmode && <th className="pl-3 data-table-adv-header-th">{" "}</th>}


### PR DESCRIPTION
DataTable's columns now stretch across whole length of the container, custom styling can be achieved by adding customStyle prop in DataTable's headers

<img width="831" alt="Snímek obrazovky 2022-07-06 v 20 02 45" src="https://user-images.githubusercontent.com/79644454/177614953-1312f1a7-e540-4273-a7b0-49b7cb6331bd.png">
