### PR TITLE
minus-button box-shadow fix

### DIFF
--- a/src/styles/components/button.scss
+++ b/src/styles/components/button.scss
@@ -358,3 +358,8 @@ $btn-dark-outline-hover-bg-color: var(--btn-dark-outline-hover-bg-color);
 .btn-group-sm .btn{
 	min-height: 38px;
 }
+
+.btn-edit-mode .btn-outline-danger:not(:disabled):not(.disabled):active:focus {
+	box-shadow: none;
+}
+


### PR DESCRIPTION
fixes right box shadow when minus button is hovered over and active