### PR TITLE
Refactor/language icon small screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,8 @@
 
 - Implement Breadcrumbs for small screen (INDIGO Sprint 220722, [!339](https://github.com/TeskaLabs/asab-webui/pull/339)
 
+- Move language icon beside toggle icon (INDIGO Sprint 220805, [!346](https://github.com/TeskaLabs/asab-webui/pull/346)
+
 
 ### Bugfixes
 

--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -93,7 +93,7 @@ export function Header(props) {
 			</div>
 			<div className="header-props-language">
 				{HeaderService.Items.map((item, idx) => (
-					item.component.name === "LanguageDropdown" &&
+					item.componentProps?.children === "LanguageDropdown" &&
 					<item.component key={item} {...item.componentProps} app={props.app}/>
 				))}
 			</div>
@@ -108,7 +108,7 @@ export function Header(props) {
 							<ThemeButton />
 							<HelpButton />
 							{HeaderService.Items.map((item, idx) => (
-								item.component.name !== "LanguageDropdown" ?
+								item.componentProps?.children !== "LanguageDropdown" ?
 									<NavItem key={idx}>
 										<item.component key={item} {...item.componentProps} app={props.app}/>
 									</NavItem>
@@ -117,16 +117,19 @@ export function Header(props) {
 							))}
 						</Nav>
 					)
-				:
+					:
 					<Nav className="header-props-sm" navbar>
 						<ThemeButton />
 						<HelpButton />
 						{HeaderService.Items.map((item, idx) => (
 							window.innerWidth < 1024 && item.componentProps.children !== undefined && item.componentProps.children === "LanguageDropdown" ?
-								<NavItem key={idx}>
-									<item.component key={item} {...item.componentProps} app={props.app}/>
-								</NavItem>
-							:
+								item.componentProps?.children !== "LanguageDropdown" ?
+									<NavItem key={idx}>
+										<item.component key={item} {...item.componentProps} app={props.app}/>
+									</NavItem>
+									:
+									null
+								:
 								window.innerWidth >= 1024 ?
 									<NavItem key={idx}>
 										<item.component key={item} {...item.componentProps} app={props.app}/>

--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -93,8 +93,10 @@ export function Header(props) {
 			</div>
 			<div className="header-props-language">
 				{HeaderService.Items.map((item, idx) => (
-					item.componentProps?.children === "LanguageDropdown" &&
-					<item.component key={item} {...item.componentProps} app={props.app}/>
+					window.innerWidth > 500 ?
+						item.componentProps?.children === "LanguageDropdown" && <item.component key={item} {...item.componentProps} app={props.app}/>
+						:
+						null
 				))}
 			</div>
 			
@@ -108,12 +110,17 @@ export function Header(props) {
 							<ThemeButton />
 							<HelpButton />
 							{HeaderService.Items.map((item, idx) => (
-								item.componentProps?.children !== "LanguageDropdown" ?
+								window.innerWidth > 500 ?
+									item.componentProps?.children !== "LanguageDropdown" ?
+										<NavItem key={idx}>
+											<item.component key={item} {...item.componentProps} app={props.app}/>
+										</NavItem>
+										:
+										null
+									:
 									<NavItem key={idx}>
 										<item.component key={item} {...item.componentProps} app={props.app}/>
 									</NavItem>
-									:
-									null
 							))}
 						</Nav>
 					)
@@ -123,19 +130,24 @@ export function Header(props) {
 						<HelpButton />
 						{HeaderService.Items.map((item, idx) => (
 							window.innerWidth < 1024 && item.componentProps.children !== undefined && item.componentProps.children === "LanguageDropdown" ?
-								item.componentProps?.children !== "LanguageDropdown" ?
+								window.innerWidth > 500 ?
+									item.componentProps?.children !== "LanguageDropdown" ?
+										<NavItem key={idx}>
+											<item.component key={item} {...item.componentProps} app={props.app}/>
+										</NavItem>
+									:
+										null
+								:
 									<NavItem key={idx}>
 										<item.component key={item} {...item.componentProps} app={props.app}/>
 									</NavItem>
-									:
-									null
-								:
+							:
 								window.innerWidth >= 1024 ?
 									<NavItem key={idx}>
 										<item.component key={item} {...item.componentProps} app={props.app}/>
 									</NavItem>
 								:
-									null
+										null
 						))}
 					</Nav>
 

--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -54,7 +54,7 @@ export function Header(props) {
 						))}
 					</Nav>
 				</>
-			:
+				:
 				<>
 				<div className="mobile-logo-position">
 					<Link to={href}>
@@ -91,6 +91,12 @@ export function Header(props) {
 			<div className={`header-props-toggler mr-3 p-0 ${headerProperties ? 'header-props-open' : '' }`} onClick={() => setHeaderProperties(!headerProperties)}>
 				<i className="cil-chevron-bottom"></i>
 			</div>
+			<div className="header-props-language">
+				{HeaderService.Items.map((item, idx) => (
+					item.component.name === "LanguageDropdown" &&
+					<item.component key={item} {...item.componentProps} app={props.app}/>
+				))}
+			</div>
 			
 			{/* smallscreen menu  */}
 			<div className={`header-props-sm`}>
@@ -102,9 +108,12 @@ export function Header(props) {
 							<ThemeButton />
 							<HelpButton />
 							{HeaderService.Items.map((item, idx) => (
-								<NavItem key={idx}>
-									<item.component key={item} {...item.componentProps} app={props.app}/>
-								</NavItem>
+								item.component.name !== "LanguageDropdown" ?
+									<NavItem key={idx}>
+										<item.component key={item} {...item.componentProps} app={props.app}/>
+									</NavItem>
+									:
+									null
 							))}
 						</Nav>
 					)

--- a/src/styles/components/header.scss
+++ b/src/styles/components/header.scss
@@ -74,7 +74,7 @@ $nav-bar-link: var(--nav-bar-link);
 
 // header-props
 
-.header-props-toggler, .header-props-sm {
+.header-props-language, .header-props-toggler, .header-props-sm {
 	visibility: hidden;
 	display: none;
 }
@@ -100,6 +100,16 @@ $nav-bar-link: var(--nav-bar-link);
 		display: flex;
 		justify-content: space-evenly;
 		transition: height 300ms ease;
+	}
+
+	.header-props-language {
+		visibility: visible;
+		display: inline-flex;
+		& .dropdown {
+			position: absolute;
+			right: 60px;
+			top: 16px;
+		}
 	}
 
 	.header-props-toggler{


### PR DESCRIPTION
Display language icon beside toggle icon when header is collapsed on small screens.
language icon should be visible without uncollapsing on this type of screens