### PR TITLE
Fix of the Safari bug from the workshop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,3 +387,5 @@
 - Fix overwriting values in input in Configuration due to useForm (INDIGO Sprint 220712, [!333](https://github.com/TeskaLabs/asab-webui/pull/333))
 
 - Removing bug causing limitation to scroll in the sidebar if it's items contain more than 100vh (INDIGO Sprint 220805, [!343](https://github.com/TeskaLabs/asab-webui/pull/343))
+
+- Fix Safari issues with loading of the application (INDIGO Sprint 220819, [!350](https://github.com/TeskaLabs/asab-webui/pull/350))

--- a/src/components/locationReplace.js
+++ b/src/components/locationReplace.js
@@ -1,3 +1,25 @@
+/*
+
+Use only within async functions as per example below.
+locationReplace function help to avoid unintended async actions
+before window.location.replace has finished.
+
+
+```
+import { locationReplace } from 'asab-webui';
+
+const myFunc = async () => {
+	...
+
+	const url = "url/to/replace";
+	await locationReplace(url);
+	...
+}
+
+```
+
+*/
+
 export const locationReplace = async (url) => {
 	window.location.replace(url.toString());
 	await new Promise(r => setTimeout(r, 3600 * 1000)); // Basically wait forever, this the app is going to be reloaded

--- a/src/components/locationReplace.js
+++ b/src/components/locationReplace.js
@@ -1,0 +1,4 @@
+export const locationReplace = async (url) => {
+	window.location.replace(url.toString());
+	await new Promise(r => setTimeout(r, 3600 * 1000)); // Basically wait forever, this the app is going to be reloaded
+}

--- a/src/index.js
+++ b/src/index.js
@@ -19,5 +19,6 @@ export { default as timeToString } from './components/DateTime/timeToString';
 export { default as useDateFNSLocale } from './components/DateTime/useDateFNSLocale';
 export { validateConfiguration } from './config/validateConfiguration';
 export { default as TreeMenu } from './components/TreeMenu';
+export { locationReplace } from './components/locationReplace';
 
 import "./styles/index.scss";

--- a/src/modules/auth/api.js
+++ b/src/modules/auth/api.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { locationReplace } from 'asab-webui';
 
 export class SeaCatAuthApi {
 
@@ -30,7 +31,7 @@ export class SeaCatAuthApi {
 	}
 
 	// This method will cause a navigation from the app to the OAuth2 login screen
-	login(redirect_uri, force_login_prompt) {
+	async login(redirect_uri, force_login_prompt) {
 		const params = new URLSearchParams({
 			response_type: "code",
 			scope: this.Scope,
@@ -42,7 +43,7 @@ export class SeaCatAuthApi {
 		}
 
 		let oidcURL = this.App.getServiceURL('openidconnect');
-		window.location.replace(oidcURL + "/authorize?" + params.toString());
+		await locationReplace(oidcURL + "/authorize?" + params.toString());
 	}
 
 	logout(access_token) {
@@ -115,14 +116,14 @@ export class GoogleOAuth2Api {
 	}
 
 	// This method will cause a navigation from the app to the OAuth2 login screen
-	login(redirect_uri) {
+	async login(redirect_uri) {
 		const params = new URLSearchParams({
 			response_type: "code",
 			scope: this.Scope,
 			client_id: this.ClientId,
 			redirect_uri: redirect_uri
 		});
-		window.location.replace("https://accounts.google.com/o/oauth2/auth" + "?" + params.toString());
+		await locationReplace("https://accounts.google.com/o/oauth2/auth" + "?" + params.toString());
 	}
 
 

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -5,6 +5,7 @@ import reducer from './reducer';
 import { types } from './actions'
 import { SeaCatAuthApi, GoogleOAuth2Api } from './api';
 import AccessControlScreen from './AccessControlScreen';
+import { locationReplace } from 'asab-webui';
 
 export default class AuthModule extends Module {
 
@@ -56,8 +57,7 @@ export default class AuthModule extends Module {
 				}
 
 				// Reload the app with `code` removed
-				window.location.replace(reloadUrl);
-				await new Promise(r => setTimeout(r, 3600 * 1000)); // Basically wait forever, this the app is going to be reloaded
+				await locationReplace(reloadUrl);
 			}
 
 			// Do we have an oauth token (we are authorized to use the app)
@@ -69,7 +69,7 @@ export default class AuthModule extends Module {
 					sessionStorage.removeItem('SeaCatOAuth2Token');
 					let force_login_prompt = true;
 
-					this.Api.login(this.RedirectURL, force_login_prompt);
+					await this.Api.login(this.RedirectURL, force_login_prompt);
 					return;
 				}
 
@@ -95,14 +95,15 @@ export default class AuthModule extends Module {
 				if (this.App.Navigation.Items.length > 0) {
 					await this.validateNavigation();
 				}
-
-				this._notifyOnExpiredSession(this);
+				if (this.UserInfo != null) {
+					this._notifyOnExpiredSession(this);
+				}
 			}
 
 			if ((this.UserInfo == null) && (this.MustAuthenticate)) {
 				// TODO: force_login_prompt = true to break authentication failure loop
 				let force_login_prompt = false;
-				this.Api.login(this.RedirectURL, force_login_prompt);
+				await this.Api.login(this.RedirectURL, force_login_prompt);
 				return;
 			}
 		}

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -34,7 +34,7 @@ export default class AuthModule extends Module {
 		headerService.addComponent(HeaderComponent, { AuthModule: this });
 		if (this.App.DevConfig.get('MOCK_USERINFO')) {
 			/* This section is only for DEV purposes! */
-			this.simulateUserinfo(this.App.DevConfig.get('MOCK_USERINFO'))
+			await this.simulateUserinfo(this.App.DevConfig.get('MOCK_USERINFO'))
 			/* End of DEV section */
 		} else {
 			// Check the query string for 'code'
@@ -55,7 +55,7 @@ export default class AuthModule extends Module {
 					reloadUrl = window.location.pathname + '?' + qs.toString() + window.location.hash;
 				}
 
-				// Reload the app
+				// Reload the app with `code` removed
 				window.location.replace(reloadUrl);
 				await new Promise(r => setTimeout(r, 3600 * 1000)); // Basically wait forever, this the app is going to be reloaded
 			}
@@ -119,7 +119,7 @@ export default class AuthModule extends Module {
 	}
 
 
-	simulateUserinfo(mock_userinfo) {
+	async simulateUserinfo(mock_userinfo) {
 		/*
 			This method takes parameters from devConfig settings
 
@@ -159,7 +159,7 @@ export default class AuthModule extends Module {
 		/** Check for TenantService and pass tenants list obtained from userinfo */
 		let tenants_list = mockParams.tenants;
 		if (this.App.Services.TenantService) {
-			this.App.Services.TenantService.set_tenants(tenants_list);
+			await this.App.Services.TenantService.set_tenants(tenants_list);
 		}
 	}
 
@@ -301,7 +301,7 @@ export default class AuthModule extends Module {
 		/** Check for TenantService and pass tenants list obtained from userinfo */
 		let tenants_list = this.UserInfo.tenants;
 		if (this.App.Services.TenantService) {
-			this.App.Services.TenantService.set_tenants(tenants_list);
+			await this.App.Services.TenantService.set_tenants(tenants_list);
 		}
 
 		return true;

--- a/src/modules/tenant/selector/TenantSelectionCard.js
+++ b/src/modules/tenant/selector/TenantSelectionCard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { locationReplace } from 'asab-webui';
 
 import {
 	Card, CardHeader, CardFooter, CardBody, CardTitle, CardSubtitle,
@@ -15,9 +16,9 @@ function TenantSelectionCard(props) {
 	let resources = props.userinfo?.resources;
 	let superuser = resources ? resources.indexOf('authz:superuser') !== -1 : false;
 
-	const selectTenant = (tn) => {
+	const selectTenant = async (tn) => {
 		if (tn.value !== "99999") {
-			window.location.replace(`${window.location.pathname}?tenant=${tn.value}${window.location.hash}`);
+			await locationReplace(`${window.location.pathname}?tenant=${tn.value}${window.location.hash}`);
 			return;
 		}
 	}

--- a/src/modules/tenant/service.js
+++ b/src/modules/tenant/service.js
@@ -25,21 +25,23 @@ export default class TenantService extends Service {
 		set_tenants(tenants_list) method is used for tenants obtained from userinfo
 		It is used within auth module of ASAB WebUI to dispatch the tenants to the application store
 	*/
-	set_tenants(tenants_list) {
+	async set_tenants(tenants_list) {
 		// Extract a current tenant from URL params
 		var tenant_id = this._extract_tenant_from_url();
 
 		// If tenant has not been provided in access URL, pick a first tenant from a list
-		if (tenant_id == null && tenants_list && tenants_list.length > 0) {
+		if ((tenant_id == null) && (tenants_list) && (tenants_list.length > 0)) {
 			tenant_id = tenants_list[0];
 			// ... and refresh (reload) the whole web app
 			window.location.replace(`${window.location.pathname}?tenant=${tenant_id}${window.location.hash}`);
+			await new Promise(r => setTimeout(r, 3600 * 1000)); // Basically wait forever, this the app is going to be reloaded
 			return;
 		}
 
 		// In case if the tenant list from userinfo is undefined or empty remove tenant parameter from URL
-		if (!tenants_list || tenants_list.length == 0) {
+		if ((!tenants_list) || (tenants_list.length == 0)) {
 			window.location.replace(window.location.pathname + window.location.hash);
+			await new Promise(r => setTimeout(r, 3600 * 1000)); // Basically wait forever, this the app is going to be reloaded
 			return;
 		}
 

--- a/src/modules/tenant/service.js
+++ b/src/modules/tenant/service.js
@@ -1,5 +1,6 @@
 import Service from '../../abc/Service';
 import { types } from './actions';
+import { locationReplace } from 'asab-webui';
 
 export default class TenantService extends Service {
 
@@ -7,7 +8,7 @@ export default class TenantService extends Service {
 		super(app, name);
 	}
 
-	initialize() {
+	async initialize() {
 
 		// If the tenant list is in the configuration, use it
 		// This is useful when tenants are present but auth not
@@ -17,7 +18,7 @@ export default class TenantService extends Service {
 			for (var i = 0; tenants[i] != undefined; i++) {
 				tenants_list.push(tenants[i]);
 			}
-			this.set_tenants(tenants_list);
+			await this.set_tenants(tenants_list);
 		}
 	}
 
@@ -33,15 +34,13 @@ export default class TenantService extends Service {
 		if ((tenant_id == null) && (tenants_list) && (tenants_list.length > 0)) {
 			tenant_id = tenants_list[0];
 			// ... and refresh (reload) the whole web app
-			window.location.replace(`${window.location.pathname}?tenant=${tenant_id}${window.location.hash}`);
-			await new Promise(r => setTimeout(r, 3600 * 1000)); // Basically wait forever, this the app is going to be reloaded
+			await locationReplace(`${window.location.pathname}?tenant=${tenant_id}${window.location.hash}`);
 			return;
 		}
 
 		// In case if the tenant list from userinfo is undefined or empty remove tenant parameter from URL
 		if ((!tenants_list) || (tenants_list.length == 0)) {
-			window.location.replace(window.location.pathname + window.location.hash);
-			await new Promise(r => setTimeout(r, 3600 * 1000)); // Basically wait forever, this the app is going to be reloaded
+			await locationReplace(window.location.pathname + window.location.hash);
 			return;
 		}
 


### PR DESCRIPTION
Fixed frozen refresh bug observed in Safari.

When `window.location.replace(...)` is issued on Safari, it can end up if frozen state.
The solution is to add `await new Promise(r => setTimeout(r, 3600 * 1000));` aka long running Promise just after that `replace` to ensure that Safari has enough time to initiate reload properly.

TODOs:

- [x] consider providing own function to do `window.location.replace + long running Promise`
- [x] `set_tenants` is now asynchronous, check if it is called correctly everywhere
- [x] `simulateUserinfo()` is now asynchronous, check if it is called this way everywhere
