### PR TITLE
DataTable dynamic item display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,8 @@
 
 - New design implementation (INDIGO Sprint 210712, [!286](https://github.com/TeskaLabs/asab-webui/pull/286))
 
+- Implement a dynamic height-dependent display of table item when the web page first loads (INDIGO Sprint 220902, [!356](https://github.com/TeskaLabs/asab-webui/pull/356))
+
 
 ### Refactoring
 

--- a/doc/datatable/datatable.md
+++ b/doc/datatable/datatable.md
@@ -705,10 +705,10 @@ The number of items displayed per page will be a multiple of 5.
 ```js
 import React, { useState, useEffect, useRef } from 'react';
 
-...
+	...
 
 function (props) {
-...
+	...
 	const [limit, setLimit] = useState(0);
 	const [height, setHeight] = useState(0);
 	const ref = useRef(null);
@@ -736,7 +736,7 @@ function (props) {
 			>
 		</div>
 	);
-..
+	..
 }
 ```
 

--- a/doc/datatable/datatable.md
+++ b/doc/datatable/datatable.md
@@ -290,7 +290,7 @@ Example of fetched data:
 
 # Optional
 
-`DataTable` can also accept optional props `limit`, `setLimit`, `createButton`, `buttonWithAuthz`, `customButton`, `customComponent`, `search`, `onSearch`, `isLoading`, `noItemsComponent`, `customCardBodyComponent`, `sublistsKey` and `onDownload`.
+`DataTable` can also accept optional props `limit`, `setLimit`, `createButton`, `buttonWithAuthz`, `customButton`, `customComponent`, `search`, `onSearch`, `isLoading`, `noItemsComponent`, `customCardBodyComponent`, `sublistsKey`, `onDownload`, `heightRef` and `setHeightRef`.
 
 Example of `DataTable` with all props:
 
@@ -313,6 +313,7 @@ Example of `DataTable` with all props:
 	onDownload={onDownload}
 	isLoading={isLoading}
 	noItemsComponent={noItemsComponent}
+	heightRef={heightRef}
 />
 ```
 
@@ -689,6 +690,37 @@ Property `onDownload` of `customComponent` is needed if you want to use custom c
 		generate: (row, header) => <SomeFancyComponent>{header.name} | {row.some_key}</SomeFancyComponent>,
 		onDownload: (row, header) => `${header.name} | ${row.some_key}`;
 	}
+}
+```
+
+Property `heightRef` and `setHeightRef` is needed if you want the item of elements in the table to adjust to the height of the web page when it first loads.
+NOTE: `heightRef` should be used in conjunction with the `limit` and `setLimit`.
+You will need to `useEffect`. This is where you will count the height of the container when you first load it. You will also need to `useRef`. You will need to place it on the wrapper tag. Be sure to style this tag to 100% height.
+The number of items displayed per page will be a multiple of 5.
+
+```js
+import React, { useState, useEffect, useRef } from 'react';
+
+...
+
+function (props) {
+	...
+	const [heightRef, setHeightRef] = useState(0);
+	const ref = useRef(null);
+	...
+	useEffect(() => {
+		setHeightRef(ref.current.clientHeight);
+	}, []);
+	...
+	return (
+		<div className="h-100" ref={ref}>
+			<DataTable
+				...
+				heightRef={heightRef}
+				...
+			>
+		</div>
+	);
 }
 ```
 

--- a/doc/datatable/datatable.md
+++ b/doc/datatable/datatable.md
@@ -695,9 +695,13 @@ Property `onDownload` of `customComponent` is needed if you want to use custom c
 
 Property `height` is needed if you want the item of elements in the table to adjust to the height of the web page when it first loads.
 NOTE: `height` should be used in conjunction with the `limit` and `setLimit`.
-You will need to `useEffect`. This is where you will count the height of the container when you first load it. You will also need to `useRef`. You will need to place it on the wrapper tag. Be sure to style this tag to 100% height.
+> You will need two `useEffect`:
+> 
+> - The first will calculate the height of the container when it is first loaded. 
+> - The second you need to have the number of rows displayed dynamically, you need to add a condition (`limit !== undefined`), where you call the function that gets the data for the table.
+> 
+You also need to add `useRef`. You will need to place it on the wrapper tag. Be sure to style this tag to 100% height.
 The number of items displayed per page will be a multiple of 5.
-
 ```js
 import React, { useState, useEffect, useRef } from 'react';
 
@@ -705,10 +709,18 @@ import React, { useState, useEffect, useRef } from 'react';
 
 function (props) {
 	...
-	const [limit, setLimit] = useState(10);
+	const [limit, setLimit] = useState(undefined);
 	const [height, setHeight] = useState(0);
 	const ref = useRef(null);
-	...
+	
+	const fetchData = () => {...}
+	
+	useEffect(() => {
+		if (limit != undefined) {
+			fetchData();
+		}
+	}, [limit]);
+	
 	useEffect(() => {
 		setHeight(ref.current.clientHeight);
 	}, []);

--- a/doc/datatable/datatable.md
+++ b/doc/datatable/datatable.md
@@ -290,7 +290,7 @@ Example of fetched data:
 
 # Optional
 
-`DataTable` can also accept optional props `limit`, `setLimit`, `createButton`, `buttonWithAuthz`, `customButton`, `customComponent`, `search`, `onSearch`, `isLoading`, `noItemsComponent`, `customCardBodyComponent`, `sublistsKey`, `onDownload`, `heightRef` and `setHeightRef`.
+`DataTable` can also accept optional props `limit`, `setLimit`, `createButton`, `buttonWithAuthz`, `customButton`, `customComponent`, `search`, `onSearch`, `isLoading`, `noItemsComponent`, `customCardBodyComponent`, `sublistsKey`, `onDownload` and `height`.
 
 Example of `DataTable` with all props:
 
@@ -313,7 +313,7 @@ Example of `DataTable` with all props:
 	onDownload={onDownload}
 	isLoading={isLoading}
 	noItemsComponent={noItemsComponent}
-	heightRef={heightRef}
+	height={height}
 />
 ```
 
@@ -693,8 +693,8 @@ Property `onDownload` of `customComponent` is needed if you want to use custom c
 }
 ```
 
-Property `heightRef` and `setHeightRef` is needed if you want the item of elements in the table to adjust to the height of the web page when it first loads.
-NOTE: `heightRef` should be used in conjunction with the `limit` and `setLimit`.
+Property `height` is needed if you want the item of elements in the table to adjust to the height of the web page when it first loads.
+NOTE: `height` should be used in conjunction with the `limit` and `setLimit`.
 You will need to `useEffect`. This is where you will count the height of the container when you first load it. You will also need to `useRef`. You will need to place it on the wrapper tag. Be sure to style this tag to 100% height.
 The number of items displayed per page will be a multiple of 5.
 
@@ -705,18 +705,18 @@ import React, { useState, useEffect, useRef } from 'react';
 
 function (props) {
 	...
-	const [heightRef, setHeightRef] = useState(0);
+	const [height, setHeight] = useState(0);
 	const ref = useRef(null);
 	...
 	useEffect(() => {
-		setHeightRef(ref.current.clientHeight);
+		setHeight(ref.current.clientHeight);
 	}, []);
 	...
 	return (
 		<div className="h-100" ref={ref}>
 			<DataTable
 				...
-				heightRef={heightRef}
+				height={height}
 				...
 			>
 		</div>

--- a/doc/datatable/datatable.md
+++ b/doc/datatable/datatable.md
@@ -705,6 +705,7 @@ import React, { useState, useEffect, useRef } from 'react';
 
 function (props) {
 	...
+	const [limit, setLimit] = useState(10);
 	const [height, setHeight] = useState(0);
 	const ref = useRef(null);
 	...
@@ -716,6 +717,8 @@ function (props) {
 		<div className="h-100" ref={ref}>
 			<DataTable
 				...
+				limit={limit}
+				setLimit={setLimit}
 				height={height}
 				...
 			>

--- a/doc/datatable/datatable.md
+++ b/doc/datatable/datatable.md
@@ -708,34 +708,35 @@ import React, { useState, useEffect, useRef } from 'react';
 ...
 
 function (props) {
-	...
-	const [limit, setLimit] = useState(undefined);
+...
+	const [limit, setLimit] = useState(0);
 	const [height, setHeight] = useState(0);
 	const ref = useRef(null);
-	
-	const fetchData = () => {...}
-	
-	useEffect(() => {
-		if (limit != undefined) {
-			fetchData();
-		}
-	}, [limit]);
-	
+
 	useEffect(() => {
 		setHeight(ref.current.clientHeight);
 	}, []);
-	...
+
+	useEffect(() => {
+		if (limit > 0) {
+			fetchData();
+		}
+	}, [limit]);
+
+	const fetchData = () => {...}
+
 	return (
 		<div className="h-100" ref={ref}>
 			<DataTable
-				...
-				limit={limit}
-				setLimit={setLimit}
-				height={height}
-				...
+			...
+			limit={limit}
+			setLimit={setLimit}
+			height={height}
+			...
 			>
 		</div>
 	);
+..
 }
 ```
 

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -36,7 +36,7 @@ export function DataTable ({
 	const [filterValue, setFilterValue] = useState('');
 	const [isLimitOpen, setLimitDropdown] = useState(false);
 	const timeoutRef = useRef(null);
-	const [countDigit, setCountDigit] = useState(1)
+	const [countDigit, setCountDigit] = useState(1);
 	
 	const { t } = useTranslation();
 
@@ -46,7 +46,7 @@ export function DataTable ({
 			// 48 -  is the height of one row in the table.
 			let tableRowCount = Math.floor((height - 250)/48);
 			setLimit(roundedNumRows(tableRowCount));
-		} else if ((height == undefined) && setLimit) {
+		} else if (setLimit && (height == undefined)) {
 			setLimit(10);
 		}
 	}, [height]);

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -45,7 +45,7 @@ export function DataTable ({
 			// 250 - is the height of the header and footer plus the paddings in the table.
 			// 48 -  is the height of one row in the table.
 			let tableRowCount = Math.floor((height - 250)/48);
-			setLimit(round(tableRowCount));
+			setLimit(roundedNumRows(tableRowCount));
 		} else if ((height == undefined) && setLimit) {
 			setLimit(10);
 		}
@@ -64,13 +64,18 @@ export function DataTable ({
 	}, [filterValue]);
 
 	// rounding page number divisible by 5
-	function round(x) {
-		const rowCount = Math.round(x / 5) * 5;
-		if (rowCount <= 0) {
-			return 5;
+	function roundedNumRows(x) {
+		if (Number.isInteger(x)) {
+			const rowCount = Math.round(x / 5) * 5;
+			if (rowCount <= 0) {
+				return 5;
+			} else {
+				return rowCount;
+			}
 		} else {
-			return rowCount;
+			return limit;
 		}
+
 	}
 
 	return (

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -68,12 +68,12 @@ export function DataTable ({
 		if (isNaN(x) == false) {
 			const rowCount = Math.round(x / 5) * 5;
 			if (rowCount <= 0) {
-				return 5;
+				return 5; // It is a lowest limit value
 			} else {
 				return rowCount;
 			}
 		} else {
-			return 10;
+			return 10; // It is a default limit value
 		}
 
 	}

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -41,7 +41,7 @@ export function DataTable ({
 	const { t } = useTranslation();
 
 	useEffect(() => {
-		if (heightRef !== 0) {
+		if (heightRef && heightRef !== 0) {
 			let tableRowCount = Math.floor((heightRef - 200)/48);
 			setLimit(round5(tableRowCount));
 		}

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -41,7 +41,7 @@ export function DataTable ({
 	const { t } = useTranslation();
 
 	useEffect(() => {
-		if ((height && setLimit) && (height !== 0)) {
+		if (setLimit && height && (height !== 0)) {
 			// 250 - is the height of the header and footer plus the paddings in the table.
 			// 48 -  is the height of one row in the table.
 			let tableRowCount = Math.floor((height - 250)/48);
@@ -65,7 +65,7 @@ export function DataTable ({
 
 	// rounding page number divisible by 5
 	function roundedNumRows(x) {
-		if (Number.isInteger(x)) {
+		if (isNaN(x) == false) {
 			const rowCount = Math.round(x / 5) * 5;
 			if (rowCount <= 0) {
 				return 5;
@@ -73,7 +73,7 @@ export function DataTable ({
 				return rowCount;
 			}
 		} else {
-			return limit;
+			return 10;
 		}
 
 	}

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { 
+import {
 	Card, Row, Col, ButtonGroup,
 	CardFooter, CardHeader, CardBody,
 	Button, Container
@@ -30,15 +30,22 @@ export function DataTable ({
 	customButton, customComponent,
 	customRowStyle, customRowClassName,
 	customCardBodyComponent,
-	limitValues = [10, 15, 25, 50],
-	contentLoader = true, category
-	}) {
+	limitValues = [5, 10, 15, 20, 50],
+	contentLoader = true, category, heightRef
+   }) {
 	const [filterValue, setFilterValue] = useState('');
 	const [isLimitOpen, setLimitDropdown] = useState(false);
 	const timeoutRef = useRef(null);
 	const [countDigit, setCountDigit] = useState(1)
 	
 	const { t } = useTranslation();
+
+	useEffect(() => {
+		if (heightRef !== 0) {
+			let tableRowCount = Math.floor((heightRef - 200)/48);
+			setLimit(round5(tableRowCount));
+		}
+	}, [heightRef]);
 
 	useEffect(() => {
 		if (timeoutRef.current !== null) {
@@ -51,6 +58,14 @@ export function DataTable ({
 		if (onSearch) onSearch(filterValue);
 		}, 500);
 	}, [filterValue]);
+
+	// rounding page number divisible by 5
+	function round5(x) {
+		return (x % 5) >= 2.5 ?
+			parseInt(x / 5) * 5 + 5
+		:
+			parseInt(x / 5) * 5;
+	}
 
 	return (
 		<Row className="h-100">

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -48,7 +48,6 @@ export function DataTable ({
 			setLimit(round(tableRowCount));
 		} else if (height == undefined) {
 			setLimit(10);
-			console.log(height, "condition height")
 		}
 	}, [height]);
 

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -41,7 +41,7 @@ export function DataTable ({
 	const { t } = useTranslation();
 
 	useEffect(() => {
-		if (heightRef && heightRef !== 0) {
+		if ((heightRef && setLimit) && heightRef !== 0) {
 			let tableRowCount = Math.floor((heightRef - 200)/48);
 			setLimit(round5(tableRowCount));
 		}

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -45,13 +45,6 @@ export function DataTable ({
 			// 250 - is the height of the header and footer plus the paddings in the table.
 			// 48 -  is the height of one row in the table.
 			let tableRowCount = Math.floor((height - 250)/48);
-			let exactNumRows = (height - 250)/48;
-			// if ((count !== 0) && (exactNumRows > count)) {
-			// 	setLimit(count);
-			//
-			// } else {
-			// 	setLimit(round(tableRowCount));
-			// }
 			setLimit(round(tableRowCount));
 		} else if ((height == undefined) && setLimit) {
 			setLimit(10);
@@ -72,7 +65,7 @@ export function DataTable ({
 
 	// rounding page number divisible by 5
 	function round(x) {
-		const rowCount = Math.floor(x / 5) * 5;
+		const rowCount = Math.round(x / 5) * 5;
 		if (rowCount <= 0) {
 			return 5;
 		} else {
@@ -83,7 +76,7 @@ export function DataTable ({
 	return (
 		<Row className="h-100">
 			<Col>
-				<Card className="h-100 data-table-card">
+				<Card className="h-auto data-table-card">
 					<CardHeader className="data-table-card-header border-bottom">
 						<div className="data-table-title card-header-title">
 							{title.icon && typeof title.icon === 'string' ? 
@@ -170,7 +163,6 @@ export function DataTable ({
 								lastPage={Math.ceil(count/limit)}
 							/>
 						}
-
 					</CardFooter>
 				</Card>
 			</Col>

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -30,7 +30,7 @@ export function DataTable ({
 	customButton, customComponent,
 	customRowStyle, customRowClassName,
 	customCardBodyComponent,
-	limitValues = [5, 10, 15, 20, 50],
+	limitValues = [5, 10, 15, 20, 25, 30, 50],
 	contentLoader = true, category, height
    }) {
 	const [filterValue, setFilterValue] = useState('');
@@ -41,19 +41,26 @@ export function DataTable ({
 	const { t } = useTranslation();
 
 	useEffect(() => {
-		if ((height && setLimit) && height !== 0) {
+		if ((height && setLimit) && (height !== 0)) {
 			// 250 - is the height of the header and footer plus the paddings in the table.
 			// 48 -  is the height of one row in the table.
 			let tableRowCount = Math.floor((height - 250)/48);
+			let exactNumRows = (height - 250)/48;
+			// if ((count !== 0) && (exactNumRows > count)) {
+			// 	setLimit(count);
+			//
+			// } else {
+			// 	setLimit(round(tableRowCount));
+			// }
 			setLimit(round(tableRowCount));
-		} else if (height == undefined) {
+		} else if ((height == undefined) && setLimit) {
 			setLimit(10);
 		}
 	}, [height]);
 
 	useEffect(() => {
 		if (timeoutRef.current !== null) {
-		clearTimeout(timeoutRef.current);
+			clearTimeout(timeoutRef.current);
 		}
 
 		timeoutRef.current = setTimeout(() => {
@@ -65,10 +72,12 @@ export function DataTable ({
 
 	// rounding page number divisible by 5
 	function round(x) {
-		return (x % 5) >= 2.5 ?
-			parseInt(x / 5) * 5 + 5
-		:
-			parseInt(x / 5) * 5;
+		const rowCount = Math.floor(x / 5) * 5;
+		if (rowCount <= 0) {
+			return 5;
+		} else {
+			return rowCount;
+		}
 	}
 
 	return (
@@ -111,7 +120,6 @@ export function DataTable ({
 							}
 						</ButtonGroup>
 					</CardHeader>
-
 					<CardBody className="data-table-card-body">
 						{customCardBodyComponent}
 						{!isLoading && <Table
@@ -132,7 +140,6 @@ export function DataTable ({
 					</CardBody>
 
 					<CardFooter className="data-table-card-footer  border-top">
-
 						<div className="data-table-card-footer-left">
 							{setLimit &&
 								<LimitDropdown 

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -31,7 +31,7 @@ export function DataTable ({
 	customRowStyle, customRowClassName,
 	customCardBodyComponent,
 	limitValues = [5, 10, 15, 20, 50],
-	contentLoader = true, category, heightRef
+	contentLoader = true, category, height
    }) {
 	const [filterValue, setFilterValue] = useState('');
 	const [isLimitOpen, setLimitDropdown] = useState(false);
@@ -41,11 +41,16 @@ export function DataTable ({
 	const { t } = useTranslation();
 
 	useEffect(() => {
-		if ((heightRef && setLimit) && heightRef !== 0) {
-			let tableRowCount = Math.floor((heightRef - 200)/48);
-			setLimit(round5(tableRowCount));
+		if ((height && setLimit) && height !== 0) {
+			// 250 - is the height of the header and footer plus the paddings in the table.
+			// 48 -  is the height of one row in the table.
+			let tableRowCount = Math.floor((height - 250)/48);
+			setLimit(round(tableRowCount));
+		} else if (height == undefined) {
+			setLimit(10);
+			console.log(height, "condition height")
 		}
-	}, [heightRef]);
+	}, [height]);
 
 	useEffect(() => {
 		if (timeoutRef.current !== null) {
@@ -60,7 +65,7 @@ export function DataTable ({
 	}, [filterValue]);
 
 	// rounding page number divisible by 5
-	function round5(x) {
+	function round(x) {
 		return (x % 5) >= 2.5 ?
 			parseInt(x / 5) * 5 + 5
 		:


### PR DESCRIPTION
 Dynamically set up items per page by the height of the screen
 
These changes add the ability to dynamically display the number of rows in the table on the first load. To do this, the height and setLimit must be passed to the table props. If no setLimit is added, no information will be displayed in the table. The table will be empty.