### PR TITLE
Refactor form-text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,8 @@
 
 - Refactor dynamic branding (INDIGO Sprint 220902, [!355](https://github.com/TeskaLabs/asab-webui/pull/355)
 
+- Replace class form-text (INDIGO Sprint 220902, [!358](https://github.com/TeskaLabs/asab-webui/pull/358)
+
 
 ### Bugfixes
 

--- a/src/styles/components/input.scss
+++ b/src/styles/components/input.scss
@@ -77,10 +77,11 @@ $disabled-input-background-color: var(--disabled-input-background-color);
     }
 }
 
+.form-text {
+    color: $text-secondary-color !important;
+}
+
 .form-group {
-    .form-text {
-        color: $text-secondary-color !important;
-    }
     .form-control.is-invalid {
         border-color: $danger;
     }


### PR DESCRIPTION
I have replace this style to make it suitable for all the examples where it will be used.
This style uses the <FormText> components.
This change comes with a marge-request in the SeaCat WebUI. 