### PR TITLE
Fix crush app customCellStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release Candidate
 
+### Bugfixes
+
+- Change const variable customCellStyle to let variable in DataTable (INDIGO Sprint 221031, [!374](https://github.com/TeskaLabs/asab-webui/pull/374))
+
 ## v22.42
 
 ### Refactoring

--- a/src/components/DataTable/Table.js
+++ b/src/components/DataTable/Table.js
@@ -16,7 +16,7 @@ const TableCell = ({
 	if (!obj) return <td className="pl-3" style={{ whiteSpace: "nowrap" }}>-</td>
 
 	let cell, icon, customCellStyle;
-	const textLinkStyle = {
+	let textLinkStyle = {
 		whiteSpace: "nowrap",
 		marginBottom: 0
 	}


### PR DESCRIPTION
The variable customCellStyles was be a `const` because of it, in app, I have this Error 
![image](https://user-images.githubusercontent.com/65866093/199245151-9cb7c82e-e0fa-4fa6-ad66-0fbe0cc80c00.png)


I changed `const` to `let`