### PR TITLE
Fix Card-Header styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release Candidate
 
+### Bugfixes
+
+- Fix styles for so long title in CardHeader (INDIGO Sprint 221125, [!377](https://github.com/TeskaLabs/asab-webui/pull/377))
+
 ## v22.46
 
 ### Features

--- a/src/styles/components/card.scss
+++ b/src/styles/components/card.scss
@@ -26,7 +26,6 @@ $box-shadow-card-color: var(--box-shadow-card-color);
 		padding: 0;
 		display: flex;
 		justify-content: space-between;
-    	min-height: 50px;
 		flex-wrap: wrap;
 		box-sizing:content-box;
 		& h3 {
@@ -37,8 +36,8 @@ $box-shadow-card-color: var(--box-shadow-card-color);
 			font-style: normal;
 			font-weight: 500;
 			font-size: 1rem;
-			line-height: 50px;
 			margin: auto 1.25rem;
+			padding: 13px 0;
 			min-height:  50px;
 			[class^="cil-"], [class*=" cil-"] {
 				color: $primary;
@@ -89,6 +88,7 @@ $box-shadow-card-color: var(--box-shadow-card-color);
 		// color: $text-secondary-color !important;
 		.card-header-title {
 			margin: 0.25rem auto;
+			padding: 0;
 			height: auto;
 			display: flex;
 			flex-direction: column;


### PR DESCRIPTION
Fix broken widget card-header

Before:
![image](https://user-images.githubusercontent.com/65866093/203262453-69e9cd0f-3f00-4133-89ba-ed139a769b8b.png)

After:
![image](https://user-images.githubusercontent.com/65866093/203262795-81f89538-113a-4b35-ae09-968429d973d5.png)


After changing the styles, the headers look exactly the same and their functionality is intact. I have tested this with all the variants we have in the app

