### PR TITLE
Refactor tree item node marking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release Candidate
 
+### Refactoring
+
+- In TreeMenu component, display all closed folder nodes (even empty) with plus mark (`+`) to visually separate it from file nodes (INDIGO Sprint 221209, [!380](https://github.com/TeskaLabs/asab-webui/pull/380))
+
 ## v22.48
 
 ### Breaking changes

--- a/src/components/TreeMenu/TreeMenuItem.js
+++ b/src/components/TreeMenu/TreeMenuItem.js
@@ -19,7 +19,7 @@ const TreeMenuItem = ({
 			className={`tree-menu-item${selected}${disabled}`}
 			style={{ paddingLeft: `${paddingLeft}rem` }}
 		>
-			{hasNodes && (
+			{(type == "folder") && (
 				<div
 					style={{ display: 'inline-block' }}
 					onClick={e => {


### PR DESCRIPTION
- In Treemenu component, display all closed folder nodes (even empty) with plus mark (`+`) to visually separate it from file nodes