### PR TITLE
Bug: not display a Helpcomoponent when changing pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 
 - Remove `react-markdown` and `rehype-raw` libraries forn HelpButton, instead of this use usual `<div>` (INDIGO Sprint 230317, [!399](https://github.com/TeskaLabs/asab-webui/pull/399))
 
+### Bugfix
+
+- Bug fix for HelpComponent, not display a Helpcomoponent when the user changing the page (INDIGO Sprint 230317, [!401](https://github.com/TeskaLabs/asab-webui/pull/401))
+
 ## v23.5
 
 ### Features

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -442,7 +442,12 @@ class Application extends Component {
 
 	addHelpButton(path) {
 		useEffect(() => {
-			this.HelpService.setData(path);
+			this.HelpService.setData(path);return () => {
+				this.Store.dispatch({
+					type: HELP_CONTENT,
+					content: ""
+				})
+			}
 		}, [])
 	}
 

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -442,7 +442,8 @@ class Application extends Component {
 
 	addHelpButton(path) {
 		useEffect(() => {
-			this.HelpService.setData(path);return () => {
+			this.HelpService.setData(path);
+			return () => {
 				this.Store.dispatch({
 					type: HELP_CONTENT,
 					content: ""


### PR DESCRIPTION
## Before changes:

https://user-images.githubusercontent.com/65866093/227501687-326aafa9-60be-49d4-959a-4e2b66ce6659.mp4

## After changes:

https://user-images.githubusercontent.com/65866093/227501897-d76af936-3b21-44e7-9d94-5e09aaf498fb.mp4

---
### Changes
1. Reset the content to default value. Add `return` to useEffect

https://github.com/TeskaLabs/asab-webui/pull/393#discussion_r1138314780
This change has been removed here https://github.com/TeskaLabs/asab-webui/pull/393#discussion_r1138314780 . I did not pay attention to it during testing