### PR TITLE
Remove removeAttributeQuotes from webpack build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Implement HelpComponent which shows the page description (INDIGO Sprint 230317, [!393](https://github.com/TeskaLabs/asab-webui/pull/393))
 
+- Add `minifyJS` and `minifyCSS` to webpack build HtmlWebPackPlugin to increase loading performance. (INDIGO Sprint 230317, [!420](https://github.com/TeskaLabs/asab-webui/pull/420))
+
 ### Refactoring
 
 - Refactor naming for `get_current_tenant`, `set_tenants` and `_extract_tenant_from_url` from snake_case to camelCase format (INDIGO Sprint 230203, [!388](https://github.com/TeskaLabs/asab-webui/pull/388))
@@ -35,6 +37,8 @@
 ### Bugfix
 
 - Bug fix for HelpComponent, not display a Helpcomoponent when the user changing the page (INDIGO Sprint 230317, [!401](https://github.com/TeskaLabs/asab-webui/pull/401))
+
+- Remove `removeAttributeQuotes` from HtmlWebPackPlugin setup in webpack.build to fix issue causing custom branding and CSS files are not being injected via nginx to the application. `removeAttributeQuotes` caused quotes removal in html tags which led to issue that tags has not been correctly injected. (INDIGO Sprint 230317, [!420](https://github.com/TeskaLabs/asab-webui/pull/420))
 
 ## v23.5
 

--- a/webpack/webpack.build.js
+++ b/webpack/webpack.build.js
@@ -55,9 +55,16 @@ module.exports = {
 			new HtmlWebpackPlugin({
 				template: html_template_path,
 				minify: {
-					removeAttributeQuotes: true,
 					collapseWhitespace: true,
-					removeComments: true
+					removeComments: true,
+					minifyJS: true,
+					minifyCSS: true
+					// TODO: eventually uncomment for better performance of the page
+					// useShortDoctype: true,
+					// removeEmptyAttributes: true,
+					// removeStyleLinkTypeAttributes: true,
+					// keepClosingSlash: true,
+					// minifyURLs: true
 				}
 			}),
 			new InterpolateHtmlPlugin(


### PR DESCRIPTION
 - Remove removeAttributeQuotes from webpack build causing failing injections of metatags from nginx
 - Add minifying of CSS and JS