### PR TITLE
PRevent infinite userinfo loop when timeout time is zero or negative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 
 - Fix `console.error` to `console.warn` (INDIGO Sprint 230331, [!406](https://github.com/TeskaLabs/asab-webui/pull/406))
 
+- Fix infinite loop bug on userinfo, when expiration time is set to small values (INDIGO Sprint 230414, [!410](https://github.com/TeskaLabs/asab-webui/pull/410))
+
 ## v23.5
 
 ### Features

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -145,7 +145,7 @@ export default class AuthModule extends Module {
 			}
 
 		*/
-		this.App.addAlert("warning", "ASABAuthModule|You are in DEV mode and using MOCK login parameters", 3);
+		this.App.addAlert("warning", "ASABAuthModule|You are in DEV mode and using MOCK login parameters", 3, true);
 		let mockParams = mock_userinfo;
 		if (mockParams.resources) {
 			mockParams["resources"] = Object.values(mockParams.resources)
@@ -267,7 +267,7 @@ export default class AuthModule extends Module {
 		// if session has expired
 		if (!isUserInfoUpdated && oldUserInfo) {
 			oldUserInfo = null;
-			that.App.addAlert("danger", "ASABAuthModule|Your session has expired", 3600 * 1000);
+			that.App.addAlert("danger", "ASABAuthModule|Your session has expired", 3600 * 1000, true);
 		}
 		else {
 			let exp = that.UserInfo.exp * 1000; // Expiration timestamp
@@ -286,7 +286,7 @@ export default class AuthModule extends Module {
 			* then first message will be shown until expiration date will come
 			*/
 			if ((difference < 60000) && (exp > Date.now()) && !fAlert) {
-				that.App.addAlert("warning", "ASABAuthModule|Your session will expire soon", 30);
+				that.App.addAlert("warning", "ASABAuthModule|Your session will expire soon", 30, true);
 				fAlert = true;
 			}
 
@@ -300,7 +300,7 @@ export default class AuthModule extends Module {
 
 			// Prevent infinite userinfo request loop when timeout time is zero or negative
 			if (timeout <= 0) {
-				that.App.addAlert("warning", "ASABAuthModule|Your session will expire soon", 30);
+				that.App.addAlert("warning", "ASABAuthModule|Your session will expire soon", 30, true);
 				fAlert = true;
 				// Set timeout to 30s since SeaCat Auth service is updating userinfo 1x per minute
 				timeout = 30000;

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -302,7 +302,7 @@ export default class AuthModule extends Module {
 			if (timeout <= 0) {
 				that.App.addAlert("warning", "ASABAuthModule|Your session will expire soon", 30, true);
 				fAlert = true;
-				// Set timeout to 30s since SeaCat Auth service is updating userinfo 1x per minute
+				// Set timeout to 30s since SeaCat Auth service is checking on deleted sessions 1x per minute
 				timeout = 30000;
 			}
 

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -145,7 +145,7 @@ export default class AuthModule extends Module {
 			}
 
 		*/
-		this.App.addAlert("warning", "ASABAuthModule|You are in DEV mode and using MOCK login parameters", 3, true);
+		this.App.addAlert("warning", "ASABAuthModule|You are in DEV mode and using MOCK login parameters", 3);
 		let mockParams = mock_userinfo;
 		if (mockParams.resources) {
 			mockParams["resources"] = Object.values(mockParams.resources)
@@ -267,7 +267,7 @@ export default class AuthModule extends Module {
 		// if session has expired
 		if (!isUserInfoUpdated && oldUserInfo) {
 			oldUserInfo = null;
-			that.App.addAlert("danger", "ASABAuthModule|Your session has expired", 3600 * 1000, true);
+			that.App.addAlert("danger", "ASABAuthModule|Your session has expired", 3600 * 1000);
 		}
 		else {
 			let exp = that.UserInfo.exp * 1000; // Expiration timestamp
@@ -277,16 +277,16 @@ export default class AuthModule extends Module {
 			* If userinfo expiration date has been changed then first alert flag
 			* is set to false and first message about expiration will be shown
 			*/
-			if (oldUserInfo?.exp !== that.UserInfo.exp && difference < 60000) fAlert = false;
-
+			if ((oldUserInfo?.exp !== that.UserInfo.exp) && (difference < 60000)) {
+				fAlert = false;
+			}
 
 			/**
 			* If expiration date is coming (less than 60 seconds) and first message wasn't shown
 			* then first message will be shown until expiration date will come
 			*/
-			if (difference < 60000 && exp > Date.now() && !fAlert) {
-				const expire = exp > Date.now() ? difference / 1000 : 5;
-				that.App.addAlert("warning", "ASABAuthModule|Your session will expire soon", expire, true);
+			if ((difference < 60000) && (exp > Date.now()) && !fAlert) {
+				that.App.addAlert("warning", "ASABAuthModule|Your session will expire soon", 30);
 				fAlert = true;
 			}
 
@@ -296,7 +296,16 @@ export default class AuthModule extends Module {
 			* 3) If expiration date has come then timeout will be set on 30 seconds to check if user's session has been
 			*    deleted on server side
 			*/
-			const timeout = fAlert ? difference > 0 ? difference : 30000 : difference - 60000;
+			let timeout = fAlert ? (difference > 0) ? difference : 30000 : difference - 60000;
+
+			// Prevent infinite userinfo request loop when timeout time is zero or negative
+			if (timeout <= 0) {
+				that.App.addAlert("warning", "ASABAuthModule|Your session will expire soon", 30);
+				fAlert = true;
+				// Set timeout to 30s since SeaCat Auth service is updating userinfo 1x per minute
+				timeout = 30000;
+			}
+
 			setTimeout(that._notifyOnExpiredSession, timeout, that, that.UserInfo, fAlert);
 		}
 	}


### PR DESCRIPTION
### This fix should prevent infinite userinfo loops caused by check on expired session

- prevent "infinite" userinfo loop on session expiration, when the expiration time is set too small (1s or smaller)
- The fix is implementation of condition on `timeout <= 0` and triggering and alert message + setting up a timeout to 30s (due to session removals on backend once per minute)