### PR TITLE
Refactor datatable properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@
 
 - Remove legacy Navigation and Router from Services. (INDIGO Sprint 230331, [!409](https://github.com/TeskaLabs/asab-webui/pull/409))
 
+- Update DataTable component with `collapseChildren` prop which allows to define, if children of nested table should be by default collapsed or not. (INDIGO Sprint 230414, [!411](https://github.com/TeskaLabs/asab-webui/pull/411))
+
+- Update DataTable component with `toggleChildrenOnRowClick` prop which allows user to click on the whole row to uncollapse/collapse children of nested table. (INDIGO Sprint 230414, [!411](https://github.com/TeskaLabs/asab-webui/pull/411))
+
+- Update TreeMenu with option to click on the whole row (parent) to uncollapse the nested content. (INDIGO Sprint 230414, [!411](https://github.com/TeskaLabs/asab-webui/pull/411))
+
 ### Bugfix
 
 - Bug fix for HelpComponent, not display a Helpcomoponent when the user changing the page (INDIGO Sprint 230317, [!401](https://github.com/TeskaLabs/asab-webui/pull/401))

--- a/doc/datatable/datatable.md
+++ b/doc/datatable/datatable.md
@@ -596,6 +596,26 @@ return (
 
 NOTE: If `category` prop is not defined, `collapseChildren` will have no impact on the datatable.
 
+Prop `toggleChildrenOnRowClick` is a boolean value and together with `category` prop can set cursor and onClick toggle to the whole table row, not just the toggle icon (button). So then the whole table row is clickable and collapse/uncollapse children of the parent.
+
+```js
+return (
+	<DataTable
+		...
+		data={data}
+		category={{
+			key: "parent_title",
+			sublistsKey:"children",
+			customComponent: (parentObj) => parentObj.name
+		}}
+		toggleChildrenOnRowClick={true}
+		...
+	/>
+);
+```
+
+NOTE: If `category` prop is not defined, `toggleChildrenOnRowClick` will have no impact on the datatable.
+
 Prop `onDownload` is a function that returns a list of items that needs to be downloaded. When such function is provided `DataTable` will automatically download csv with provided list.
 For downloading content which is displayed with custom components check section Custom Components.
 

--- a/doc/datatable/datatable.md
+++ b/doc/datatable/datatable.md
@@ -564,7 +564,7 @@ const headers = [
 
 ...
 return (
-	<DataTable 
+	<DataTable
 		...
 		data={data}
 		category={{
@@ -575,6 +575,26 @@ return (
 	/>
 );
 ```
+
+Prop `collapseChildren` is a boolean value and together with usage of `category` prop can collapse children nodes of the parent if set to `true`. By default is set to `false` and thus parent node is by default open and all of their children visible.
+
+```js
+return (
+	<DataTable
+		...
+		data={data}
+		category={{
+			key: "parent_title",
+			sublistsKey:"children",
+			customComponent: (parentObj) => parentObj.name
+		}}
+		collapseChildren={true}
+		...
+	/>
+);
+```
+
+NOTE: If `category` prop is not defined, `collapseChildren` will have no impact on the datatable.
 
 Prop `onDownload` is a function that returns a list of items that needs to be downloaded. When such function is provided `DataTable` will automatically download csv with provided list.
 For downloading content which is displayed with custom components check section Custom Components.

--- a/src/components/DataTable/Table.js
+++ b/src/components/DataTable/Table.js
@@ -146,10 +146,11 @@ const Headers = ({ headers, advmode, sublists }) => (
 
 const TableRow = ({
 	obj, advmode, headers,
-	rowStyle, rowClassName, category
+	rowStyle, rowClassName, category,
+	collapseChildren
 }) => {
 	const [isAdvUnwrapped, setAdvUnwrapped] = useState(false);
-	const [isSubUnwrapped, setSubUwrapped] = useState(true);
+	const [isSubUnwrapped, setSubUwrapped] = useState((collapseChildren == false) ? true : false);
 	const theme = useSelector(state => state?.theme);
 
 	const getStyle = (obj) => {
@@ -254,13 +255,14 @@ const TableRow = ({
 
 const ASABTable = ({
 	data, headers, advmode,
-	rowStyle, rowClassName, category
+	rowStyle, rowClassName, category,
+	collapseChildren
 }) => (
 	<Table size="sm" hover responsive>
 		<Headers sublists={!!category} headers={headers} advmode={advmode} className="data-table-header"/>
 		<tbody className="data-table-tbody">
 			{data && data.map((obj, idx) => (
-				<TableRow {...{ obj, advmode, headers, rowStyle, rowClassName, category }} key={idx} />
+				<TableRow {...{ obj, advmode, headers, rowStyle, rowClassName, category, collapseChildren }} key={idx} />
 			))}
 		</tbody>
 	</Table>

--- a/src/components/DataTable/Table.js
+++ b/src/components/DataTable/Table.js
@@ -147,10 +147,10 @@ const Headers = ({ headers, advmode, sublists }) => (
 const TableRow = ({
 	obj, advmode, headers,
 	rowStyle, rowClassName, category,
-	collapseChildren
+	collapseChildren, toggleChildrenOnRowClick
 }) => {
 	const [isAdvUnwrapped, setAdvUnwrapped] = useState(false);
-	const [isSubUnwrapped, setSubUwrapped] = useState((collapseChildren == false) ? true : false);
+	const [isSubUnwrapped, setSubUnwrapped] = useState((collapseChildren == false) ? true : false);
 	const theme = useSelector(state => state?.theme);
 
 	const getStyle = (obj) => {
@@ -188,20 +188,18 @@ const TableRow = ({
 
 	return (
 		<>
-			<tr className={`data-table-tr ${className}`} style={style}>
+			<tr
+				// Enable data-table-tr-cursor class only when category is present and toggleChildrenOnRowClick is set to true
+				className={`data-table-tr ${className} ${category && (toggleChildrenOnRowClick == true) && "data-table-tr-cursor"}`}
+				style={style}
+				// Enable onClick only when category is present and toggleChildrenOnRowClick is set to true
+				onClick={() => category && (toggleChildrenOnRowClick == true) && setSubUnwrapped(prev => !prev)}
+			>
 				{advmode && <TableCell obj={obj} showJson={() => setAdvUnwrapped(prev => !prev)}/>}
 				{category && (
-					<>
-						{isSubUnwrapped ? (
-							<td className="data-table-arrow-btn" onClick={() => setSubUwrapped(false)}>
-								<i className="cil-chevron-circle-down-alt"></i>
-							</td>
-						) : (
-							<td className="data-table-arrow-btn" onClick={() => setSubUwrapped(true)}>
-								<i className="cil-chevron-circle-right-alt"></i>
-							</td>
-						)}
-					</>
+					<td className="data-table-arrow-btn" onClick={() => (toggleChildrenOnRowClick == true) ? null : setSubUnwrapped(prev => !prev)}>
+						<i className={isSubUnwrapped ? "cil-chevron-circle-down-alt" : "cil-chevron-circle-right-alt"}></i>
+					</td>
 				)}
 				{
 					(headers.map((header, idx) => (
@@ -256,13 +254,13 @@ const TableRow = ({
 const ASABTable = ({
 	data, headers, advmode,
 	rowStyle, rowClassName, category,
-	collapseChildren
+	collapseChildren, toggleChildrenOnRowClick
 }) => (
 	<Table size="sm" hover responsive>
 		<Headers sublists={!!category} headers={headers} advmode={advmode} className="data-table-header"/>
 		<tbody className="data-table-tbody">
 			{data && data.map((obj, idx) => (
-				<TableRow {...{ obj, advmode, headers, rowStyle, rowClassName, category, collapseChildren }} key={idx} />
+				<TableRow {...{ obj, advmode, headers, rowStyle, rowClassName, category, collapseChildren, toggleChildrenOnRowClick }} key={idx} />
 			))}
 		</tbody>
 	</Table>

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -33,7 +33,7 @@ export function DataTable ({
 	customCardBodyComponent,
 	limitValues = [5, 10, 15, 20, 25, 30, 50],
 	contentLoader = true, category, height, disableAdvMode,
-	collapseChildren = false
+	collapseChildren = false, toggleChildrenOnRowClick = false
    }) {
 	const [filterValue, setFilterValue] = useState('');
 	const [isLimitOpen, setLimitDropdown] = useState(false);
@@ -138,6 +138,7 @@ export function DataTable ({
 								rowStyle={customRowStyle}
 								rowClassName={customRowClassName}
 								collapseChildren={collapseChildren}
+								toggleChildrenOnRowClick={toggleChildrenOnRowClick}
 								advmode={advModeState}
 							/>
 						}

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -32,7 +32,8 @@ export function DataTable ({
 	customRowStyle, customRowClassName,
 	customCardBodyComponent,
 	limitValues = [5, 10, 15, 20, 25, 30, 50],
-	contentLoader = true, category, height, disableAdvMode
+	contentLoader = true, category, height, disableAdvMode,
+	collapseChildren = false
    }) {
 	const [filterValue, setFilterValue] = useState('');
 	const [isLimitOpen, setLimitDropdown] = useState(false);
@@ -136,6 +137,7 @@ export function DataTable ({
 								category={category}
 								rowStyle={customRowStyle}
 								rowClassName={customRowClassName}
+								collapseChildren={collapseChildren}
 								advmode={advModeState}
 							/>
 						}

--- a/src/components/DataTable/table.scss
+++ b/src/components/DataTable/table.scss
@@ -47,6 +47,7 @@ thead .data-table-tr th {
     & .data-table-tr {
         height: 48px;
         & .data-table-arrow-btn {
+            padding-left: .75rem;
             [class^="cil-"], [class*=" cil-"] {
                 color: $primary;
                 cursor: pointer;

--- a/src/components/DataTable/table.scss
+++ b/src/components/DataTable/table.scss
@@ -54,6 +54,10 @@ thead .data-table-tr th {
             }
         }
     }
+
+    & .data-table-tr-cursor {
+        cursor: pointer;
+    }
 }
 
 table ~ .react-json-view {

--- a/src/components/TreeMenu/TreeMenuItem.js
+++ b/src/components/TreeMenu/TreeMenuItem.js
@@ -12,16 +12,28 @@ const TreeMenuItem = ({
 	const selected = focused ? " selected" : "";
 	const disabled = isDisabled ? " disabled" : "";
 
+	// Method to manage clicks on whole rows of the Tree item
+	const handleClick = (e) => {
+		// If type is folder and node is closed, make whole line clickable for toggling nodes
+		if ((type == "folder") && (isOpen == false)) {
+			e.stopPropagation();
+			hasNodes && toggleNode && toggleNode();
+		}
+		props.onClick && props.onClick();
+	}
+
 	return (
 		<li
 			{...props}
 			active="false"
 			className={`tree-menu-item${selected}${disabled}`}
 			style={{ paddingLeft: `${paddingLeft}rem` }}
+			onClick={e => {handleClick(e)}}
 		>
 			{(type == "folder") && (
 				<div
 					style={{ display: 'inline-block' }}
+					// Clickable toggle icon, not restricted as handleClick method
 					onClick={e => {
 						e.stopPropagation();
 						hasNodes && toggleNode && toggleNode();


### PR DESCRIPTION
- add prop to collapse children of the parent by default
- update tree menu item, that whole line is clickable on toggle when opening the folder