### PR TITLE
Feature/Relative time suffix in DateTime component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - Add componentLoader component as a helper for lazy loading to troubleshoot situations, when the lazy chunk will not be loaded due to browser cache. (INDIGO Sprint 230428, [!413](https://github.com/TeskaLabs/asab-webui/pull/413))
 
+- Added option to show suffix to indicate 'relative time' in DateTime component (INDIGO 230428, [!417](https://github.com/TeskaLabs/asab-webui/pull/417))
+
 ### Refactoring
 
 - Refactor naming for `get_current_tenant`, `set_tenants` and `_extract_tenant_from_url` from snake_case to camelCase format (INDIGO Sprint 230203, [!388](https://github.com/TeskaLabs/asab-webui/pull/388))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - Add componentLoader component as a helper for lazy loading to troubleshoot situations, when the lazy chunk will not be loaded due to browser cache. (INDIGO Sprint 230428, [!413](https://github.com/TeskaLabs/asab-webui/pull/413))
 
-- Added option to show suffix to indicate 'relative time' in DateTime component (INDIGO 230428, [!417](https://github.com/TeskaLabs/asab-webui/pull/417))
+- Added option to show suffix to indicate 'relative time' in DateTime component (INDIGO Sprint 230428, [!417](https://github.com/TeskaLabs/asab-webui/pull/417))
 
 ### Refactoring
 

--- a/src/components/DateTime/index.js
+++ b/src/components/DateTime/index.js
@@ -27,7 +27,7 @@ export function DateTime(props) {
 
 	const dateFromNow = isNaN(props.value) ? formatDistanceToNow(parseISO(props.value), { locale: locale }) :
 		props.value > 9999999999 ? formatDistanceToNow(props.value, { locale: locale }) :
-		formatDistanceToNow(props.value * 1000, { locale: locale });
+		formatDistanceToNow(props.value * 1000, { addSuffix: true, locale: locale });
 
 	return (
 		<span className="datetime" title={dateFromNow}>

--- a/src/components/DateTime/index.js
+++ b/src/components/DateTime/index.js
@@ -25,8 +25,8 @@ export function DateTime(props) {
 
 	const date = timeToString(props.value, props.dateTimeFormat);
 
-	const dateFromNow = isNaN(props.value) ? formatDistanceToNow(parseISO(props.value), { locale: locale }) :
-		props.value > 9999999999 ? formatDistanceToNow(props.value, { locale: locale }) :
+	const dateFromNow = isNaN(props.value) ? formatDistanceToNow(parseISO(props.value), { addSuffix: true, locale: locale }) :
+		props.value > 9999999999 ? formatDistanceToNow(props.value, { addSuffix: true, locale: locale }) :
 		formatDistanceToNow(props.value * 1000, { addSuffix: true, locale: locale });
 
 	return (


### PR DESCRIPTION
#### in this PR 

* addSufix option added to formatDistanceToNow params in DateTime component


<img width="757" alt="Screenshot 2023-05-08 at 11 06 08" src="https://user-images.githubusercontent.com/79644454/236786029-c0f45e0d-c431-4826-99b9-d4d3ef195224.png">
<img width="426" alt="Screenshot 2023-05-08 at 11 06 34" src="https://user-images.githubusercontent.com/79644454/236786036-515903ed-01d2-44bc-a6cb-03fb0c0a5126.png">
