### PR TITLE
updated preview-flag for implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### Features
 
-- Added reusable component which will display a flag with custom defined name in the header of the app (INDIGO Spring 230623, [!433](https://github.com/TeskaLabs/asab-webui/pull/433))
+- Add different flag names and new color to previewFlag component (INDIGO Spring 230721, [!440](https://github.com/TeskaLabs/asab-webui/pull/440))
+
+- Add reusable component which will display a flag with custom defined name in the header of the app (INDIGO Spring 230623, [!433](https://github.com/TeskaLabs/asab-webui/pull/433))
 
 - Implement `getTenantData` method to Tenant service (INDIGO Sprint 230203, [!388](https://github.com/TeskaLabs/asab-webui/pull/388))
 

--- a/src/containers/Header/PreviewFlag.js
+++ b/src/containers/Header/PreviewFlag.js
@@ -1,16 +1,24 @@
-import React from 'react';
-import {useTranslation} from "react-i18next";
+import React, { useEffect } from 'react';
+import { useTranslation } from "react-i18next";
+import { useSelector } from 'react-redux';
 
 export default function PreviewFlag({ name }) {
     const flagName = name?.toLowerCase();
-    const {t} = useTranslation();
+    const { t } = useTranslation();
+    const theme = useSelector(state=>state?.theme);
 
+    useEffect(() => {
+        const element = document.querySelector('.preview-flag');
+        if (element) {
+          element.classList.toggle('preview-flag-dark', theme === 'dark');
+          element.classList.toggle('preview-flag-light', theme === 'light');
+        }
+    }, [theme]);
+ 
     if(flagName === "preview") {
         name = t("AnalysisContainer|Preview")
-
     } else if(flagName === "alpha") {
         name = "Alpha";
-
     } else if(flagName === "beta") {
         name = "Beta";
     } else {
@@ -19,7 +27,7 @@ export default function PreviewFlag({ name }) {
 
     return (
         <>
-            <span className="preview-flag">
+            <span className="badge badge-warning mr-4 preview-flag">
                 { name }
             </span>
         </>

--- a/src/containers/Header/PreviewFlag.js
+++ b/src/containers/Header/PreviewFlag.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from "react-i18next";
 import { useSelector } from 'react-redux';
 

--- a/src/containers/Header/PreviewFlag.js
+++ b/src/containers/Header/PreviewFlag.js
@@ -6,14 +6,6 @@ export default function PreviewFlag({ name }) {
     const flagName = name?.toLowerCase();
     const { t } = useTranslation();
     const theme = useSelector(state=>state?.theme);
-
-    useEffect(() => {
-        const element = document.querySelector('.preview-flag');
-        if (element) {
-          element.classList.toggle('preview-flag-dark', theme === 'dark');
-          element.classList.toggle('preview-flag-light', theme === 'light');
-        }
-    }, [theme]);
  
     if(flagName === "preview") {
         name = t("AnalysisContainer|Preview")
@@ -27,7 +19,7 @@ export default function PreviewFlag({ name }) {
 
     return (
         <>
-            <span className="badge badge-warning mr-4 preview-flag">
+            <span className={`badge badge-warning mr-4 preview-flag ${theme == "light" ? "preview-flag-light" : "preview-flag-dark"}`}>
                 { name }
             </span>
         </>

--- a/src/containers/Header/PreviewFlag.js
+++ b/src/containers/Header/PreviewFlag.js
@@ -1,8 +1,20 @@
 import React from 'react';
+import {useTranslation} from "react-i18next";
 
 export default function PreviewFlag({ name }) {
-    if(!name) {
-        return null
+    const flagName = name?.toLowerCase();
+    const {t} = useTranslation();
+
+    if(flagName === "preview") {
+        name = t("AnalysisContainer|Preview")
+
+    } else if(flagName === "alpha") {
+        name = "Alpha";
+
+    } else if(flagName === "beta") {
+        name = "Beta";
+    } else {
+        return null;
     }
 
     return (

--- a/src/containers/Header/header.scss
+++ b/src/containers/Header/header.scss
@@ -34,8 +34,4 @@ $toggle-text-color: var(--toggle-text-color);
 	font-size: 1rem;
 	color: var(--warning);
 	margin-right: 1.5rem;	
-	// color: $toggle-text-color;
-	// color: var(--info);
-	// color: var(--danger);
 }
-

--- a/src/containers/Header/header.scss
+++ b/src/containers/Header/header.scss
@@ -32,7 +32,10 @@ $toggle-text-color: var(--toggle-text-color);
 
 .preview-flag {
 	font-size: 1rem;
-	color: $toggle-text-color;
+	color: var(--warning);
 	margin-right: 1.5rem;	
+	// color: $toggle-text-color;
+	// color: var(--info);
+	// color: var(--danger);
 }
 

--- a/src/containers/Header/header.scss
+++ b/src/containers/Header/header.scss
@@ -30,8 +30,11 @@ $toggle-text-color: var(--toggle-text-color);
 
 }
 
-.preview-flag {
-	font-size: 1rem;
-	color: var(--warning);
-	margin-right: 1.5rem;	
+.preview-flag-dark {
+	color: $toggle-text-color;
 }
+
+.preview-flag-light {
+	color: $text-color;
+}
+

--- a/src/containers/Header/header.scss
+++ b/src/containers/Header/header.scss
@@ -31,7 +31,7 @@ $toggle-text-color: var(--toggle-text-color);
 }
 
 .preview-flag-dark {
-	color: $toggle-text-color;
+	color: $night-blue;
 }
 
 .preview-flag-light {

--- a/src/containers/Header/header.scss
+++ b/src/containers/Header/header.scss
@@ -13,6 +13,7 @@ $toggle-text-color: var(--toggle-text-color);
 	&.modal-dialog {
 		max-width: 960px;
 	}
+	
 	& .modal-content {
 		border: 0;
 		border-radius: 8px;
@@ -27,7 +28,6 @@ $toggle-text-color: var(--toggle-text-color);
 		overflow: hidden;
 		border: 0;
 	}
-
 }
 
 .preview-flag-dark {

--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -122,7 +122,7 @@ export function Header(props) {
 						{(props.app.props.hasSidebar || typeof props.app.props.hasSidebar === 'undefined') &&
 							(
 								<Nav navbar>
-									<PreviewFlag />
+									<PreviewFlag name={flag} />
 									<HelpButton />
 									<ThemeButton />
 									{HeaderService.Items.map((item, idx) => (

--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -122,7 +122,7 @@ export function Header(props) {
 						{(props.app.props.hasSidebar || typeof props.app.props.hasSidebar === 'undefined') &&
 							(
 								<Nav navbar>
-									<PreviewFlag name={flag} />
+									<PreviewFlag />
 									<HelpButton />
 									<ThemeButton />
 									{HeaderService.Items.map((item, idx) => (


### PR DESCRIPTION
- preparing the preview flag component for implementation (with names - preview / alpha / beta)
- implementing preview flag in user analysis and host analysis

no flag in home: 
![no-flag](https://github.com/TeskaLabs/asab-webui/assets/31582696/6aec202a-427a-4c6e-8a6d-a8ca4749568a)

flag in (for example) user analysis
![user-analyis-eng](https://github.com/TeskaLabs/asab-webui/assets/31582696/6a30e605-ca29-4c71-b292-101f275fae9d)
