### PR TITLE
Hotfix on Invalid date in timeToString formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,11 @@
 
 - Add missing locales for HelpButton (INDIGO Sprint 230623, [!436](https://github.com/TeskaLabs/asab-webui/pull/436))
 
+### Hotfix
+
+- Hotfix on DateTime component - Invalid date in timeToString formatting, preventing app failure (INDIGO Sprint 230804, [!443](https://github.com/TeskaLabs/asab-webui/pull/443))
+
+
 ## v23.5
 
 ### Features

--- a/src/components/DateTime/index.js
+++ b/src/components/DateTime/index.js
@@ -13,18 +13,19 @@ export function DateTime(props) {
 
 	// Declaration of locale must be below span returned for `undefined` values to avoid bad react state handling in useDateFNSLocale
 	const locale = useDateFNSLocale();
-
 	if (new Date(props.value).toString() === "Invalid Date") {
 		return (
-			<span className='datetime'>
-				<i className="cil-clock pr-1"></i>
-				Invalid Date
-			</span>
+			<InvalidDate />
 		);
 	}
 
 	const date = timeToString(props.value, props.dateTimeFormat);
-
+	// Check for invalid date from timeToString method
+	if (date === "Invalid Date") {
+		return (
+			<InvalidDate />
+		);
+	}
 	const dateFromNow = isNaN(props.value) ? formatDistanceToNow(parseISO(props.value), { addSuffix: true, locale: locale }) :
 		props.value > 9999999999 ? formatDistanceToNow(props.value, { addSuffix: true, locale: locale }) :
 		formatDistanceToNow(props.value * 1000, { addSuffix: true, locale: locale });
@@ -33,6 +34,16 @@ export function DateTime(props) {
 		<span className="datetime" title={dateFromNow}>
 			<i className="cil-clock pr-1"></i>
 			{date}
+		</span>
+	);
+}
+
+// Mehod for rendering invalid date component
+function InvalidDate(props) {
+	return (
+		<span className='datetime'>
+			<i className="cil-clock pr-1"></i>
+			Invalid Date
 		</span>
 	);
 }

--- a/src/components/DateTime/timeToString.js
+++ b/src/components/DateTime/timeToString.js
@@ -9,7 +9,6 @@ const timeToString = (value, dateTimeFormat = "medium") => {
 	
 	// Declaration of locale must be below empty string returned for `undefined` values to avoid bad react state handling in useDateFNSLocale
 	const locale = useDateFNSLocale();
-	
 	if (new Date(value).toString() === "Invalid Date") {
 		return 'Invalid Date';
 	}
@@ -17,6 +16,10 @@ const timeToString = (value, dateTimeFormat = "medium") => {
 	let date;
 
 	if (isNaN(value) == true) {
+		// Checking dates for parsing
+		if (parseISO(value) == "Invalid Date") {
+			return "Invalid Date";
+		}
 		if (dateTimeFormat === "medium") {
 			date = format(parseISO(value), 'PPp', { locale });
 		} else if (dateTimeFormat === "long") {


### PR DESCRIPTION
 Hotfix on Invalid date in timeToString formatting, preventing app failure