### PR TITLE
Fix sending props for TreeMenuItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@
 
 - Add missing locales for HelpButton (INDIGO Sprint 230623, [!436](https://github.com/TeskaLabs/asab-webui/pull/436))
 
+- Fixed passing of props to the TreeMenuItem component (INDIGO Sprint 230804, [!446](https://github.com/TeskaLabs/asab-webui/pull/446))
+
 ### Hotfix
 
 - Hotfix on DateTime component - Invalid date in timeToString formatting, preventing app failure (INDIGO Sprint 230804, [!443](https://github.com/TeskaLabs/asab-webui/pull/443))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@
 
 - Add missing locales for HelpButton (INDIGO Sprint 230623, [!436](https://github.com/TeskaLabs/asab-webui/pull/436))
 
-- Fixed passing of props to the TreeMenuItem component (INDIGO Sprint 230804, [!446](https://github.com/TeskaLabs/asab-webui/pull/446))
+- Fixed passing of props to the TreeMenuItem component (INDIGO Sprint 230818, [!446](https://github.com/TeskaLabs/asab-webui/pull/446))
 
 ### Hotfix
 

--- a/src/components/TreeMenu/index.js
+++ b/src/components/TreeMenu/index.js
@@ -44,8 +44,9 @@ const TreeMenu = ({
 							{items.map(({ reset, ...params }) => (
 								<TreeMenuItem
 									active="false"
+									resource={props.resource}
+									resources={props.resources}
 									{...params}
-									{...props}
 								/>
 							))}
 						</ListGroup>


### PR DESCRIPTION
TreeMenuItem needs to receive only resources and resource from `props`. Necessary parameters for library work come from `params`. Passing `props` completely causes errors in console, because these data are inserted as arguments to tags. 


If these changes pass inspection, I can contact Katya to have her update this on the microfrontend. And I can also update our applications to remove this bug in other applications.